### PR TITLE
Update to Mockito 2.2.29

### DIFF
--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -17,5 +17,5 @@ repositories {
 dependencies {
     compile project(":dexmaker")
 
-    compile 'org.mockito:mockito-core:1.10.19'
+    compile 'org.mockito:mockito-core:2.2.29'
 }

--- a/dexmaker-mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
+++ b/dexmaker-mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
@@ -17,10 +17,6 @@
 package com.android.dx.mockito;
 
 import com.android.dx.stock.ProxyBuilder;
-
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.Set;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.exceptions.stacktrace.StackTraceCleaner;
 import org.mockito.invocation.MockHandler;
@@ -28,15 +24,21 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.MockMaker;
 import org.mockito.plugins.StackTraceCleanerProvider;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
+import java.util.Set;
+
 /**
  * Generates mock instances on Android's runtime.
  */
 public final class DexmakerMockMaker implements MockMaker, StackTraceCleanerProvider {
     private final UnsafeAllocator unsafeAllocator = UnsafeAllocator.create();
 
+    @Override
     public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
         Class<T> typeToMock = settings.getTypeToMock();
-        Set<Class> interfacesSet = settings.getExtraInterfaces();
+        Set<Class<?>> interfacesSet = settings.getExtraInterfaces();
         Class<?>[] extraInterfaces = interfacesSet.toArray(new Class[interfacesSet.size()]);
         InvocationHandler invocationHandler = new InvocationHandlerAdapter(handler);
 
@@ -45,9 +47,9 @@ public final class DexmakerMockMaker implements MockMaker, StackTraceCleanerProv
             Class[] classesToMock = new Class[extraInterfaces.length + 1];
             classesToMock[0] = typeToMock;
             System.arraycopy(extraInterfaces, 0, classesToMock, 1, extraInterfaces.length);
-            @SuppressWarnings("unchecked") // newProxyInstance returns the type of typeToMock
-            T mock = (T) Proxy.newProxyInstance(typeToMock.getClassLoader(),
-                    classesToMock, invocationHandler);
+            // newProxyInstance returns the type of typeToMock
+            @SuppressWarnings("unchecked")
+            T mock = (T) Proxy.newProxyInstance(typeToMock.getClassLoader(), classesToMock, invocationHandler);
             return mock;
 
         } else {
@@ -67,14 +69,52 @@ public final class DexmakerMockMaker implements MockMaker, StackTraceCleanerProv
         }
     }
 
+    @Override
     public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
         InvocationHandlerAdapter adapter = getInvocationHandlerAdapter(mock);
         adapter.setHandler(newHandler);
     }
 
+    @Override
+    public TypeMockability isTypeMockable(final Class<?> type) {
+        return new TypeMockability() {
+            @Override
+            public boolean mockable() {
+                return !type.isPrimitive() && !Modifier.isFinal(type.getModifiers());
+            }
+
+            @Override
+            public String nonMockableReason() {
+                if (type.isPrimitive()) {
+                    return "primitive type";
+                }
+
+                if (Modifier.isFinal(type.getModifiers())) {
+                    return "final or anonymous class";
+                }
+
+                return "not handled type";
+            }
+        };
+    }
+
+    @Override
     public MockHandler getHandler(Object mock) {
         InvocationHandlerAdapter adapter = getInvocationHandlerAdapter(mock);
         return adapter != null ? adapter.getHandler() : null;
+    }
+
+    @Override
+    public StackTraceCleaner getStackTraceCleaner(final StackTraceCleaner defaultCleaner) {
+        return new StackTraceCleaner() {
+            @Override
+            public boolean isIn(StackTraceElement candidate) {
+                return defaultCleaner.isIn(candidate)
+                        && !candidate.getClassName().endsWith("_Proxy") // dexmaker class proxies
+                        && !candidate.getClassName().startsWith("$Proxy") // dalvik interface proxies
+                        && !candidate.getClassName().startsWith("com.google.dexmaker.mockito.");
+            }
+        };
     }
 
     private InvocationHandlerAdapter getInvocationHandlerAdapter(Object mock) {
@@ -96,16 +136,5 @@ public final class DexmakerMockMaker implements MockMaker, StackTraceCleanerProv
         }
 
         return null;
-    }
-
-    public StackTraceCleaner getStackTraceCleaner(final StackTraceCleaner defaultCleaner) {
-        return new StackTraceCleaner() {
-            public boolean isOut(StackTraceElement candidate) {
-                return defaultCleaner.isOut(candidate)
-                        || candidate.getClassName().endsWith("_Proxy") // dexmaker class proxies
-                        || candidate.getClassName().startsWith("$Proxy") // dalvik interface proxies
-                        || candidate.getClassName().startsWith("com.google.dexmaker.mockito.");
-            }
-        };
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ org.gradle.jvmargs=-Djava.awt.headless=true
 # org.gradle.parallel=true
 
 GROUP_ID=com.linkedin.dexmaker
-VERSION_NAME=1.6.0-SNAPSHOT
+VERSION_NAME=2.2.0-SNAPSHOT


### PR DESCRIPTION
This commit also changes the next snapshot version to be
2.2.0 instead of 1.6.0. The intention is to make the major
and minor version of dexmaker stay in line with the major
and minor version of Mockito that is supported. Mockito's
patch version is updated with every commit released, and we
may want releases of dexmaker that don't change the version
of Mockito that we depend on so there's not much benefit in
staying in sync with that.

Also worth noting, this commit doesn't do anything to support
mocking final methods. This just fixes dexmaker to work with
Mockito 2.2.x core.