### PR TITLE
Better stack trace cleaning

### DIFF
--- a/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/CleanStackTrace.java
+++ b/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/CleanStackTrace.java
@@ -14,25 +14,21 @@
  * limitations under the License.
  */
 
-package com.android.dx.mockito.tests;
-
-import android.support.test.runner.AndroidJUnit4;
+package com.android.dx.mockito.inline.tests;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.exceptions.base.MockitoException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-@RunWith(AndroidJUnit4.class)
-public class MockTests {
+public class CleanStackTrace {
+    public abstract static class TestAbstractClass {
+        public abstract String returnA();
+    }
+
     public static class TestClass {
-        public String returnA() {
+        public final String returnA() {
             return "A";
         }
     }
@@ -42,52 +38,8 @@ public class MockTests {
     }
 
     @Test
-    public void mockClass() throws Exception {
-        TestClass t = mock(TestClass.class);
-
-        assertNull(t.returnA());
-
-        when(t.returnA()).thenReturn("B");
-        assertEquals("B", t.returnA());
-    }
-
-    @Test
-    public void mockInterface() throws Exception {
-        TestInterface t = mock(TestInterface.class);
-
-        assertNull(t.returnA());
-
-        when(t.returnA()).thenReturn("B");
-        assertEquals("B", t.returnA());
-    }
-
-    @Test
-    public void spyClass() throws Exception {
-        TestClass originalT = new TestClass();
-        TestClass t = spy(originalT);
-
-        assertEquals("A", t.returnA());
-
-        when(t.returnA()).thenReturn("B");
-        assertEquals("B", t.returnA());
-
-        // Wrapped object is not affected by mocking
-        assertEquals("A", originalT.returnA());
-    }
-
-    @Test
-    public void spyNewClass() throws Exception {
-        TestClass t = spy(TestClass.class);
-
-        assertEquals("A", t.returnA());
-
-        when(t.returnA()).thenReturn("B");
-        assertEquals("B", t.returnA());
-    }
-
-    @Test
     public void cleanStackTraceProxy() {
-        TestClass t = mock(TestClass.class);
+        TestAbstractClass t = mock(TestAbstractClass.class);
 
         try {
             verify(t).returnA();
@@ -97,6 +49,22 @@ public class MockTests {
             } catch (Exception here) {
                 assertEquals(here.getStackTrace()[0].getMethodName(), verifyLocation
                         .getStackTrace()[0].getMethodName());
+            }
+        }
+    }
+
+    @Test
+    public void cleanStackTraceInline() {
+        TestClass t = mock(TestClass.class);
+
+        try {
+            verify(t).returnA();
+        } catch (Throwable verifyLocation) {
+            try {
+                throw new Exception();
+            } catch (Exception here) {
+                assertEquals(here.getStackTrace()[0].getMethodName(), verifyLocation
+                        .getStackTrace()[1].getMethodName());
             }
         }
     }

--- a/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/MockFinal.java
+++ b/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/MockFinal.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
-public class MockFinalTests {
+public class MockFinal {
     @Test
     public void mockFinalJavaMethod() throws Exception {
         ClassLoader fakeParent = mock(ClassLoader.class);

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/DexmakerStackTraceCleaner.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/DexmakerStackTraceCleaner.java
@@ -29,17 +29,21 @@ public final class DexmakerStackTraceCleaner implements StackTraceCleanerProvide
         return new StackTraceCleaner() {
             @Override
             public boolean isIn(StackTraceElement candidate) {
+                String className = candidate.getClassName();
+
                 return defaultCleaner.isIn(candidate)
                         // dexmaker class proxies
-                        && !candidate.getClassName().endsWith("_Proxy")
+                        && !className.endsWith("_Proxy")
 
-                        && !candidate.getClassName().startsWith("java.lang.reflect.Method")
-                        && !candidate.getClassName().startsWith("java.lang.reflect.Proxy")
-                        && !candidate.getClassName().startsWith("com.android.dx.mockito.")
+                        && !className.startsWith("java.lang.reflect.Method")
+                        && !className.startsWith("java.lang.reflect.Proxy")
+                        && !(className.startsWith("com.android.dx.mockito.")
+                             // Do not clean unit tests
+                             && !className.startsWith("com.android.dx.mockito.inline.tests"))
 
                         // dalvik interface proxies
-                        && !candidate.getClassName().startsWith("$Proxy")
-                        && !candidate.getClassName().matches(".*\\.\\$Proxy[\\d]+");
+                        && !className.startsWith("$Proxy")
+                        && !className.matches(".*\\.\\$Proxy[\\d]+");
             }
         };
     }

--- a/dexmaker-mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
+++ b/dexmaker-mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
@@ -109,10 +109,15 @@ public final class DexmakerMockMaker implements MockMaker, StackTraceCleanerProv
         return new StackTraceCleaner() {
             @Override
             public boolean isIn(StackTraceElement candidate) {
+                String className = candidate.getClassName();
+
                 return defaultCleaner.isIn(candidate)
-                        && !candidate.getClassName().endsWith("_Proxy") // dexmaker class proxies
-                        && !candidate.getClassName().startsWith("$Proxy") // dalvik interface proxies
-                        && !candidate.getClassName().startsWith("com.google.dexmaker.mockito.");
+                        && !className.endsWith("_Proxy") // dexmaker class proxies
+                        && !className.startsWith("$Proxy") // dalvik interface proxies
+                        && !className.startsWith("java.lang.reflect.Proxy")
+                        && !(className.startsWith("com.android.dx.mockito.")
+                             // Do not clean unit tests
+                             && !className.startsWith("com.android.dx.mockito.tests"));
             }
         };
     }


### PR DESCRIPTION
- Upstream "Filter out reflexion calls":
https://android.googlesource.com/platform/external/dexmaker/+/cbb59739ed1b0c95cbfadd23049ab84ded8899a9%5E%21/
- Upstream "Filter updated package name":
https://android.googlesource.com/platform/external/dexmaker/+/2baaa47e3e86c4148d511a4375b10410553ffcf0%5E%21/

Also added tests for stack trace cleaning