### PR TITLE
Multiple Jvmti agents can't interfere with mocking

### DIFF
--- a/dexmaker-mockito-inline-tests/CMakeLists.txt
+++ b/dexmaker-mockito-inline-tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.4.1)
+
+set(slicer_sources
+    ../dexmaker-mockito-inline/external/slicer/bytecode_encoder.cc
+    ../dexmaker-mockito-inline/external/slicer/code_ir.cc
+    ../dexmaker-mockito-inline/external/slicer/common.cc
+    ../dexmaker-mockito-inline/external/slicer/control_flow_graph.cc
+    ../dexmaker-mockito-inline/external/slicer/debuginfo_encoder.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_bytecode.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_format.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_ir_builder.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_ir.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_utf8.cc
+    ../dexmaker-mockito-inline/external/slicer/instrumentation.cc
+    ../dexmaker-mockito-inline/external/slicer/reader.cc
+    ../dexmaker-mockito-inline/external/slicer/tryblocks_encoder.cc
+    ../dexmaker-mockito-inline/external/slicer/writer.cc)
+
+add_library(slicer
+            STATIC
+            ${slicer_sources})
+
+include_directories(../dexmaker-mockito-inline/external/jdk ../dexmaker-mockito-inline/external/slicer/)
+
+target_link_libraries(slicer z)
+
+add_library(multiplejvmtiagentsinterferenceagent
+            SHARED
+            src/main/jni/multiplejvmtiagentsinterferenceagent/agent.cc)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -frtti -Wall -Werror -Wno-unused-parameter -Wno-shift-count-overflow -Wno-error=non-virtual-dtor -Wno-sign-compare -Wno-switch -Wno-missing-braces")
+
+target_link_libraries(multiplejvmtiagentsinterferenceagent slicer)

--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -16,6 +16,12 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
+    externalNativeBuild {
+        cmake {
+            path 'CMakeLists.txt'
+        }
+    }
 }
 
 repositories {

--- a/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/MultipleJvmtiAgentsInterference.java
+++ b/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/MultipleJvmtiAgentsInterference.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.tests;
+
+import android.os.Build;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import dalvik.system.BaseDexClassLoader;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
+
+public class MultipleJvmtiAgentsInterference {
+    private static final String AGENT_LIB_NAME = "multiplejvmtiagentsinterferenceagent";
+
+    public class TestClass {
+        public String returnA() {
+            return "A";
+        }
+    }
+
+    @BeforeClass
+    public static void installTestAgent() throws Exception {
+        // TODO (moltmann@google.com): Replace with proper check for >= P
+        assumeTrue(Build.VERSION.CODENAME.equals("P"));
+
+        // Currently Debug.attachJvmtiAgent requires a file in the right directory
+        File copiedAgent = File.createTempFile("testagent", ".so");
+        copiedAgent.deleteOnExit();
+
+        try (InputStream is = new FileInputStream(((BaseDexClassLoader)
+                MultipleJvmtiAgentsInterference.class.getClassLoader()).findLibrary
+                (AGENT_LIB_NAME))) {
+            try (OutputStream os = new FileOutputStream(copiedAgent)) {
+                byte[] buffer = new byte[64 * 1024];
+
+                while (true) {
+                    int numRead = is.read(buffer);
+                    if (numRead == -1) {
+                        break;
+                    }
+                    os.write(buffer, 0, numRead);
+                }
+            }
+        }
+
+        // TODO (moltmann@google.com): Replace with regular method call once the API becomes public
+        Class.forName("android.os.Debug").getMethod("attachJvmtiAgent", String.class, String
+                .class).invoke(null, copiedAgent.getAbsolutePath(), null);
+    }
+
+    @Test
+    public void otherAgentTransformsWhileMocking() {
+        TestClass t = mock(TestClass.class);
+
+        assertNull(t.returnA());
+
+        // Unrelated class re-transform does not affect mocking
+        nativeRetransformClasses(new Class<?>[]{MultipleJvmtiAgentsInterference.class});
+        assertNull(t.returnA());
+
+        // Re-transform of classes that are mocked does not affect mocking
+        nativeRetransformClasses(new Class<?>[]{TestClass.class});
+        assertNull(t.returnA());
+    }
+
+    private native int nativeRetransformClasses(Class<?>[] classes);
+}

--- a/dexmaker-mockito-inline-tests/src/main/jni/multiplejvmtiagentsinterferenceagent/agent.cc
+++ b/dexmaker-mockito-inline-tests/src/main/jni/multiplejvmtiagentsinterferenceagent/agent.cc
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jni.h>
+
+#include <cstring>
+#include <cstdlib>
+#include <sstream>
+
+#include "jvmti.h"
+
+#include <dex_ir.h>
+#include <writer.h>
+#include <reader.h>
+
+using namespace dex;
+
+namespace com_android_dx_mockito_inline_tests {
+    static jvmtiEnv *localJvmtiEnv;
+
+    // Converts a class name to a type descriptor
+    // (ex. "java.lang.String" to "Ljava/lang/String;")
+    static std::string
+    ClassNameToDescriptor(const char* class_name) {
+        std::stringstream ss;
+        ss << "L";
+        for (auto p = class_name; *p != '\0'; ++p) {
+            ss << (*p == '.' ? '/' : *p);
+        }
+        ss << ";";
+        return ss.str();
+    }
+
+    static void
+    Transform(jvmtiEnv *jvmti_env,
+              JNIEnv *env,
+              jclass classBeingRedefined,
+              jobject loader,
+              const char *name,
+              jobject protectionDomain,
+              jint classDataLen,
+              const unsigned char *classData,
+              jint *newClassDataLen,
+              unsigned char **newClassData) {
+        // Isolate byte code of class class. This is needed as Android usually gives us more
+        // than the class we need.
+        // Then just return the isolated byte code without modification.
+        Reader reader(classData, (size_t) classDataLen);
+
+        u4 index = reader.FindClassIndex(ClassNameToDescriptor(name).c_str());
+        reader.CreateClassIr(index);
+        std::shared_ptr<ir::DexFile> ir = reader.GetIr();
+
+        struct Allocator : public Writer::Allocator {
+            virtual void* Allocate(size_t size) {return ::malloc(size);}
+            virtual void Free(void* ptr) {::free(ptr);}
+        };
+
+        Allocator allocator;
+        Writer writer(ir);
+        size_t newClassLen;
+        *newClassData = writer.CreateImage(&allocator, &newClassLen);
+        *newClassDataLen = (jint) newClassLen;
+    }
+
+    // Initializes the agent
+    extern "C" jint Agent_OnAttach(JavaVM *vm,
+                                   char *options,
+                                   void *reserved) {
+        jint jvmError = vm->GetEnv(reinterpret_cast<void **>(&localJvmtiEnv), JVMTI_VERSION_1_2);
+        if (jvmError != JNI_OK) {
+            return jvmError;
+        }
+
+        jvmtiCapabilities caps;
+        memset(&caps, 0, sizeof(caps));
+        caps.can_retransform_classes = 1;
+
+        jvmtiError error = localJvmtiEnv->AddCapabilities(&caps);
+        if (error != JVMTI_ERROR_NONE) {
+            return error;
+        }
+
+        jvmtiEventCallbacks cb;
+        memset(&cb, 0, sizeof(cb));
+        cb.ClassFileLoadHook = Transform;
+
+        error = localJvmtiEnv->SetEventCallbacks(&cb, sizeof(cb));
+        if (error != JVMTI_ERROR_NONE) {
+            return error;
+        }
+
+        error = localJvmtiEnv->SetEventNotificationMode(JVMTI_ENABLE,
+                                                        JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                                        NULL);
+        if (error != JVMTI_ERROR_NONE) {
+            return error;
+        }
+
+        return JVMTI_ERROR_NONE;
+    }
+
+
+    // Triggers retransformation of classes via this file's Transform method
+    extern "C" JNIEXPORT jint JNICALL
+    Java_com_android_dx_mockito_inline_tests_MultipleJvmtiAgentsInterference_nativeRetransformClasses(
+            JNIEnv *env,
+            jobject thiz,
+            jobjectArray classes) {
+        jsize numTransformedClasses = env->GetArrayLength(classes);
+        jclass *transformedClasses = (jclass *) malloc(numTransformedClasses * sizeof(jclass));
+        for (int i = 0; i < numTransformedClasses; i++) {
+            transformedClasses[i] = (jclass) env->NewGlobalRef(env->GetObjectArrayElement(classes,
+                                                                                          i));
+        }
+
+        jvmtiError error = localJvmtiEnv->RetransformClasses(numTransformedClasses,
+                                                             transformedClasses);
+
+        for (int i = 0; i < numTransformedClasses; i++) {
+            env->DeleteGlobalRef(transformedClasses[i]);
+        }
+        free(transformedClasses);
+
+        return error;
+    }
+}

--- a/dexmaker-mockito-inline/CMakeLists.txt
+++ b/dexmaker-mockito-inline/CMakeLists.txt
@@ -1,8 +1,24 @@
 cmake_minimum_required(VERSION 3.4.1)
 
+set(slicer_sources
+    external/slicer/bytecode_encoder.cc
+    external/slicer/code_ir.cc
+    external/slicer/common.cc
+    external/slicer/control_flow_graph.cc
+    external/slicer/debuginfo_encoder.cc
+    external/slicer/dex_bytecode.cc
+    external/slicer/dex_format.cc
+    external/slicer/dex_ir_builder.cc
+    external/slicer/dex_ir.cc
+    external/slicer/dex_utf8.cc
+    external/slicer/instrumentation.cc
+    external/slicer/reader.cc
+    external/slicer/tryblocks_encoder.cc
+    external/slicer/writer.cc)
+
 add_library(slicer
             STATIC
-            external/slicer/bytecode_encoder.cc external/slicer/code_ir.cc external/slicer/common.cc external/slicer/control_flow_graph.cc external/slicer/debuginfo_encoder.cc external/slicer/dex_bytecode.cc external/slicer/dex_format.cc external/slicer/dex_ir_builder.cc external/slicer/dex_ir.cc external/slicer/dex_utf8.cc external/slicer/instrumentation.cc external/slicer/reader.cc external/slicer/tryblocks_encoder.cc external/slicer/writer.cc)
+            ${slicer_sources})
 
 include_directories(external/jdk external/slicer/)
 

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/ClassTransformer.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/ClassTransformer.java
@@ -172,9 +172,8 @@ class ClassTransformer {
      *
      * @return transformed class
      */
-    @SuppressWarnings("unused")
-    public byte[] transform(Class<?> classBeingRedefined,
-                            byte[] classfileBuffer) throws IllegalClassFormatException {
+    byte[] transform(Class<?> classBeingRedefined, byte[] classfileBuffer) throws
+            IllegalClassFormatException {
         if (classBeingRedefined == null
                 || !mockedTypes.contains(classBeingRedefined)) {
             return null;

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
@@ -41,6 +41,8 @@ class JvmtiAgent {
     /** Registered byte code transformers */
     private final ArrayList<ClassTransformer> transformers = new ArrayList<>();
 
+    private native void nativeRegisterTransformerHook();
+
     /**
      * Enable jvmti and load agent.
      *
@@ -103,6 +105,15 @@ class JvmtiAgent {
                         loadJvmtiException);
             }
         }
+
+        nativeRegisterTransformerHook();
+    }
+
+    private native void nativeUnregisterTransformerHook();
+
+    @Override
+    protected void finalize() throws Throwable {
+        nativeUnregisterTransformerHook();
     }
 
     private native static void nativeAppendToBootstrapClassLoaderSearch(String absolutePath);

--- a/dexmaker-mockito-inline/src/main/jni/dexmakerjvmtiagent/agent.cc
+++ b/dexmaker-mockito-inline/src/main/jni/dexmakerjvmtiagent/agent.cc
@@ -118,7 +118,7 @@ Transform(jvmtiEnv* jvmti_env,
 
             jbyte* transformed = env->GetByteArrayElements(transformedArr, 0);
 
-            *newClassData = (unsigned char*) malloc(*newClassDataLen);
+            jvmti_env->Allocate(*newClassDataLen, newClassData);
             std::memcpy(*newClassData, transformed, *newClassDataLen);
 
             env->ReleaseByteArrayElements(transformedArr, transformed, 0);

--- a/dexmaker-mockito-inline/src/main/jni/dexmakerjvmtiagent/agent.cc
+++ b/dexmaker-mockito-inline/src/main/jni/dexmakerjvmtiagent/agent.cc
@@ -40,8 +40,6 @@ namespace com_android_dx_mockito_inline {
 static jvmtiEnv* localJvmtiEnv;
 
 static jobject sTransformer;
-static jint sNumTransformedClasses;
-static jclass* sTransformedClasses;
 
 // Converts a class name to a type descriptor
 // (ex. "java.lang.String" to "Ljava/lang/String;")
@@ -72,64 +70,58 @@ Transform(jvmtiEnv* jvmti_env,
           jint* newClassDataLen,
           unsigned char** newClassData) {
     if (sTransformer != NULL) {
-        for (int i = 0; i < sNumTransformedClasses; i++) {
-            if (env->IsSameObject(sTransformedClasses[i], classBeingRedefined)) {
-                // Isolate byte code of class class. This is needed as Android usually gives us more
-                // than the class we need.
-                Reader reader(classData, classDataLen);
+        // Isolate byte code of class class. This is needed as Android usually gives us more
+        // than the class we need.
+        Reader reader(classData, classDataLen);
 
-                u4 index = reader.FindClassIndex(ClassNameToDescriptor(name).c_str());
-                reader.CreateClassIr(index);
-                std::shared_ptr<ir::DexFile> ir = reader.GetIr();
+        u4 index = reader.FindClassIndex(ClassNameToDescriptor(name).c_str());
+        reader.CreateClassIr(index);
+        std::shared_ptr<ir::DexFile> ir = reader.GetIr();
 
-                struct Allocator : public Writer::Allocator {
-                    virtual void* Allocate(size_t size) {return ::malloc(size);}
-                    virtual void Free(void* ptr) {::free(ptr);}
-                };
+        struct Allocator : public Writer::Allocator {
+            virtual void* Allocate(size_t size) {return ::malloc(size);}
+            virtual void Free(void* ptr) {::free(ptr);}
+        };
 
-                Allocator allocator;
-                Writer writer(ir);
-                size_t isolatedClassLen = 0;
-                std::shared_ptr<jbyte> isolatedClass((jbyte*)writer.CreateImage(&allocator,
-                                                                                &isolatedClassLen));
+        Allocator allocator;
+        Writer writer(ir);
+        size_t isolatedClassLen = 0;
+        std::shared_ptr<jbyte> isolatedClass((jbyte*)writer.CreateImage(&allocator,
+                                                                        &isolatedClassLen));
 
-                // Create jbyteArray with isolated byte code of class
-                jbyteArray isolatedClassArr = env->NewByteArray(isolatedClassLen);
-                env->SetByteArrayRegion(isolatedClassArr, 0, isolatedClassLen,
-                                        isolatedClass.get());
+        // Create jbyteArray with isolated byte code of class
+        jbyteArray isolatedClassArr = env->NewByteArray(isolatedClassLen);
+        env->SetByteArrayRegion(isolatedClassArr, 0, isolatedClassLen,
+                                isolatedClass.get());
 
-                jstring nameStr = env->NewStringUTF(name);
+        jstring nameStr = env->NewStringUTF(name);
 
-                // Call JvmtiAgent#runTransformers
-                jclass cls = env->GetObjectClass(sTransformer);
-                jmethodID runTransformers = env->GetMethodID(cls, "runTransformers",
-                                                             "(Ljava/lang/ClassLoader;"
-                                                             "Ljava/lang/String;"
-                                                             "Ljava/lang/Class;"
-                                                             "Ljava/security/ProtectionDomain;"
-                                                             "[B)[B");
+        // Call JvmtiAgent#runTransformers
+        jclass cls = env->GetObjectClass(sTransformer);
+        jmethodID runTransformers = env->GetMethodID(cls, "runTransformers",
+                                                     "(Ljava/lang/ClassLoader;"
+                                                     "Ljava/lang/String;"
+                                                     "Ljava/lang/Class;"
+                                                     "Ljava/security/ProtectionDomain;"
+                                                     "[B)[B");
 
-                jbyteArray transformedArr = (jbyteArray) env->CallObjectMethod(sTransformer,
-                                                                               runTransformers,
-                                                                               loader, nameStr,
-                                                                               classBeingRedefined,
-                                                                               protectionDomain,
-                                                                               isolatedClassArr);
+        jbyteArray transformedArr = (jbyteArray) env->CallObjectMethod(sTransformer,
+                                                                       runTransformers,
+                                                                       loader, nameStr,
+                                                                       classBeingRedefined,
+                                                                       protectionDomain,
+                                                                       isolatedClassArr);
 
-                // Set transformed byte code
-                if (!env->ExceptionOccurred() && transformedArr != NULL) {
-                    *newClassDataLen = env->GetArrayLength(transformedArr);
+        // Set transformed byte code
+        if (!env->ExceptionOccurred() && transformedArr != NULL) {
+            *newClassDataLen = env->GetArrayLength(transformedArr);
 
-                    jbyte* transformed = env->GetByteArrayElements(transformedArr, 0);
+            jbyte* transformed = env->GetByteArrayElements(transformedArr, 0);
 
-                    *newClassData = (unsigned char*) malloc(*newClassDataLen);
-                    std::memcpy(*newClassData, transformed, *newClassDataLen);
+            *newClassData = (unsigned char*) malloc(*newClassDataLen);
+            std::memcpy(*newClassData, transformed, *newClassDataLen);
 
-                    env->ReleaseByteArrayElements(transformedArr, transformed, 0);
-                }
-
-                break;
-            }
+            env->ReleaseByteArrayElements(transformedArr, transformed, 0);
         }
     }
 }
@@ -836,33 +828,39 @@ static void throwRuntimeExpection(JNIEnv* env, const char* fmt, ...) {
     env->ThrowNew(exceptionClass, msgBuf);
 }
 
-// Triggers retransformation of classes
+// Register transformer hook
+extern "C" JNIEXPORT void JNICALL
+Java_com_android_dx_mockito_inline_JvmtiAgent_nativeRegisterTransformerHook(JNIEnv* env,
+                                                                            jobject thiz) {
+    sTransformer = env->NewGlobalRef(thiz);
+}
+
+// Unregister transformer hook
+extern "C" JNIEXPORT void JNICALL
+Java_com_android_dx_mockito_inline_JvmtiAgent_nativeUnregisterTransformerHook(JNIEnv* env,
+                                                                              jobject thiz) {
+    env->DeleteGlobalRef(sTransformer);
+    sTransformer = NULL;
+}
+
+// Triggers retransformation of classes via this file's Transform method
 extern "C" JNIEXPORT void JNICALL
 Java_com_android_dx_mockito_inline_JvmtiAgent_nativeRetransformClasses(JNIEnv* env,
                                                                        jobject thiz,
                                                                        jobjectArray classes) {
-    sNumTransformedClasses = env->GetArrayLength(classes);
-    sTransformedClasses = (jclass*) malloc(sNumTransformedClasses * sizeof(jclass));
-    for (int i = 0; i < sNumTransformedClasses; i++) {
-         sTransformedClasses[i] = (jclass) env->NewGlobalRef(env->GetObjectArrayElement(classes,
-                                                                                        i));
+    jsize numTransformedClasses = env->GetArrayLength(classes);
+    jclass *transformedClasses = (jclass*) malloc(numTransformedClasses * sizeof(jclass));
+    for (int i = 0; i < numTransformedClasses; i++) {
+        transformedClasses[i] = (jclass) env->NewGlobalRef(env->GetObjectArrayElement(classes, i));
     }
 
-    sTransformer = env->NewGlobalRef(thiz);
+    jvmtiError error = localJvmtiEnv->RetransformClasses(numTransformedClasses,
+                                                         transformedClasses);
 
-    jvmtiError error = localJvmtiEnv->RetransformClasses(sNumTransformedClasses,
-                                                         sTransformedClasses);
-
-    env->DeleteGlobalRef(sTransformer);
-    sTransformer = NULL;
-
-    for (int i = 0; i < sNumTransformedClasses; i++) {
-        env->DeleteGlobalRef(sTransformedClasses[i]);
+    for (int i = 0; i < numTransformedClasses; i++) {
+        env->DeleteGlobalRef(transformedClasses[i]);
     }
-    free(sTransformedClasses);
-    sTransformedClasses = NULL;
-
-    sNumTransformedClasses = 0;
+    free(transformedClasses);
 
     if (error != JVMTI_ERROR_NONE) {
         throwRuntimeExpection(env, "Could not retransform classes: %d", error);


### PR DESCRIPTION
If a class transformation is requested by any agent, the transformation
starts from the original code. Hence if we previosly added entry hooks
to a class, we now have to add them again. To do that we call into
ClassTransformer#transform every time a class get transformed, not only
when this was triggerd via ClassTransformer#mockClass.

Also added a test that simulates this behavior.

Unfortuantely the test required the slicer lib and jvmti.h again, so I
needed to copy it.