### PR TITLE
Correct error in case of additional invocations

### DIFF
--- a/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/tests
+++ b/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/tests
@@ -1,0 +1,1 @@
+../../../../../../../../dexmaker-mockito-tests/src/androidTest/java/com/android/dx/mockito/tests

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/DexmakerStackTraceCleaner.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/DexmakerStackTraceCleaner.java
@@ -39,6 +39,7 @@ public final class DexmakerStackTraceCleaner implements StackTraceCleanerProvide
                         && !className.startsWith("java.lang.reflect.Proxy")
                         && !(className.startsWith("com.android.dx.mockito.")
                              // Do not clean unit tests
+                             && !className.startsWith("com.android.dx.mockito.tests")
                              && !className.startsWith("com.android.dx.mockito.inline.tests"))
 
                         // dalvik interface proxies

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InvocationHandlerAdapter.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InvocationHandlerAdapter.java
@@ -18,6 +18,7 @@ package com.android.dx.mockito.inline;
 
 import org.mockito.internal.creation.DelegatingMethod;
 import org.mockito.internal.debugging.LocationImpl;
+import org.mockito.internal.exceptions.VerificationAwareInvocation;
 import org.mockito.internal.invocation.ArgumentsProcessor;
 import org.mockito.internal.progress.SequenceNumber;
 import org.mockito.invocation.Invocation;
@@ -123,7 +124,7 @@ final class InvocationHandlerAdapter implements InvocationHandler {
     /**
      * Invocation on a proxy
      */
-    private class ProxyInvocation implements Invocation {
+    private class ProxyInvocation implements Invocation, VerificationAwareInvocation {
         private final Object proxy;
         private final Method method;
         private final Object[] rawArgs;

--- a/dexmaker-mockito-tests/src/androidTest/java/com/android/dx/mockito/tests/CleanStackTrace.java
+++ b/dexmaker-mockito-tests/src/androidTest/java/com/android/dx/mockito/tests/CleanStackTrace.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.android.dx.mockito.inline.tests;
+package com.android.dx.mockito.tests;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -28,7 +29,7 @@ public class CleanStackTrace {
     }
 
     public static class TestClass {
-        public final String returnA() {
+        public String returnA() {
             return "A";
         }
     }
@@ -38,7 +39,7 @@ public class CleanStackTrace {
     }
 
     @Test
-    public void cleanStackTraceProxy() {
+    public void cleanStackTraceAbstractClass() {
         TestAbstractClass t = mock(TestAbstractClass.class);
 
         try {
@@ -54,7 +55,7 @@ public class CleanStackTrace {
     }
 
     @Test
-    public void cleanStackTraceInline() {
+    public void cleanStackTraceRegularClass() {
         TestClass t = mock(TestClass.class);
 
         try {
@@ -63,8 +64,15 @@ public class CleanStackTrace {
             try {
                 throw new Exception();
             } catch (Exception here) {
-                assertEquals(here.getStackTrace()[0].getMethodName(), verifyLocation
-                        .getStackTrace()[1].getMethodName());
+                // Depending on the mock maker TestClass.returnA might be in the stack trace or not
+                for (int i = 0; i < 2; i++) {
+                    if (verifyLocation.getStackTrace()[i].getMethodName().equals(here
+                            .getStackTrace()[0].getMethodName())) {
+                        return;
+                    }
+                }
+
+                fail();
             }
         }
     }

--- a/dexmaker-mockito-tests/src/androidTest/java/com/android/dx/mockito/tests/GeneralMocking.java
+++ b/dexmaker-mockito-tests/src/androidTest/java/com/android/dx/mockito/tests/GeneralMocking.java
@@ -20,17 +20,18 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.exceptions.base.MockitoException;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
-public class MockTests {
+public class GeneralMocking {
     public static class TestClass {
         public String returnA() {
             return "A";
@@ -86,34 +87,23 @@ public class MockTests {
     }
 
     @Test
-    public void cleanStackTraceProxy() {
+    public void verifyAdditionalInvocations() {
         TestClass t = mock(TestClass.class);
 
+        t.returnA();
+        t.returnA();
+
         try {
-            verify(t).returnA();
-        } catch (Throwable verifyLocation) {
+            verifyNoMoreInteractions(t);
+        } catch (NoInteractionsWanted e) {
             try {
                 throw new Exception();
             } catch (Exception here) {
-                assertEquals(here.getStackTrace()[0].getMethodName(), verifyLocation
-                        .getStackTrace()[0].getMethodName());
+                // The error message should indicate where the additional invocations have been made
+                assertTrue(e.getMessage(),
+                        e.getMessage().contains(here.getStackTrace()[0].getMethodName()));
             }
-        }
-    }
 
-    @Test
-    public void cleanStackTraceInterface() {
-        TestInterface t = mock(TestInterface.class);
-
-        try {
-            verify(t).returnA();
-        } catch (Throwable verifyLocation) {
-            try {
-                throw new Exception();
-            } catch (Exception here) {
-                assertEquals(here.getStackTrace()[0].getMethodName(), verifyLocation
-                        .getStackTrace()[0].getMethodName());
-            }
         }
     }
 }

--- a/dexmaker-mockito/src/main/java/com/android/dx/mockito/InvocationHandlerAdapter.java
+++ b/dexmaker-mockito/src/main/java/com/android/dx/mockito/InvocationHandlerAdapter.java
@@ -20,6 +20,7 @@ import com.android.dx.stock.ProxyBuilder;
 
 import org.mockito.internal.creation.DelegatingMethod;
 import org.mockito.internal.debugging.LocationImpl;
+import org.mockito.internal.exceptions.VerificationAwareInvocation;
 import org.mockito.internal.invocation.ArgumentsProcessor;
 import org.mockito.internal.progress.SequenceNumber;
 import org.mockito.invocation.Invocation;
@@ -80,7 +81,7 @@ final class InvocationHandlerAdapter implements InvocationHandler {
     /**
      * Invocation on a proxy
      */
-    private class ProxyInvocation implements Invocation {
+    private class ProxyInvocation implements Invocation, VerificationAwareInvocation {
         private final Object proxy;
         private final Method method;
         private final Object[] rawArgs;


### PR DESCRIPTION
NoInteractionsWanted exceptions require the invocations to be
VerificationAwareInvocation's.

Also run all "regular" mocking tests in the inline test suite.