### PR TITLE
Issue #77: Switch Dexmaker-inline to preview SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,7 @@ env:
 before_install:
   - mkdir $ANDROID_HOME/licenses
   - echo -ne "\n8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e" >> $ANDROID_HOME/licenses/android-sdk-license
+  - echo -ne "\n79120722343a6f314e0719f863036c702b0e6b2a\n84831b9409646a918e30573bab4c9c91346d8abd" >> $ANDROID_HOME/licenses/android-sdk-preview-license
   - $ANDROID_HOME/tools/bin/sdkmanager "ndk-bundle"
   - $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.6.4111459"
+  - $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-P"

--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 'android-P'
     buildToolsVersion "25.0.0"
 
     lintOptions {

--- a/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/MultipleJvmtiAgentsInterference.java
+++ b/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/MultipleJvmtiAgentsInterference.java
@@ -17,18 +17,11 @@
 package com.android.dx.mockito.inline.tests;
 
 import android.os.Build;
+import android.os.Debug;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-
-import dalvik.system.BaseDexClassLoader;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeTrue;
@@ -48,9 +41,7 @@ public class MultipleJvmtiAgentsInterference {
         // TODO (moltmann@google.com): Replace with proper check for >= P
         assumeTrue(Build.VERSION.CODENAME.equals("P"));
 
-        // TODO (moltmann@google.com): Replace with regular method call once the API becomes public
-        Class.forName("android.os.Debug").getMethod("attachJvmtiAgent", String.class, String
-                .class, ClassLoader.class).invoke(null, AGENT_LIB_NAME, null,
+        Debug.attachJvmtiAgent(AGENT_LIB_NAME, null,
                 MultipleJvmtiAgentsInterference.class.getClassLoader());
     }
 

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 'android-P'
     buildToolsVersion "25.0.0"
 
     lintOptions {

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
@@ -17,13 +17,13 @@
 package com.android.dx.mockito.inline;
 
 import android.os.Build;
+import android.os.Debug;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 
@@ -56,36 +56,13 @@ class JvmtiAgent {
             throw new IOException("Requires Android P. Build is " + Build.VERSION.CODENAME);
         }
 
-        Throwable loadJvmtiException = null;
-
         ClassLoader cl = JvmtiAgent.class.getClassLoader();
         if (!(cl instanceof BaseDexClassLoader)) {
             throw new IOException("Could not load jvmti plugin as JvmtiAgent class was not loaded "
                     + "by a BaseDexClassLoader");
         }
 
-        try {
-            /*
-             * TODO (moltmann@google.com): Replace with regular method call once the API becomes
-             *                             public
-             */
-            Class.forName("android.os.Debug").getMethod("attachJvmtiAgent", String.class,
-                    String.class, ClassLoader.class).invoke(null, AGENT_LIB_NAME, null, cl);
-        } catch (InvocationTargetException e) {
-            loadJvmtiException = e.getCause();
-        } catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException e) {
-            loadJvmtiException = e;
-        }
-
-        if (loadJvmtiException != null) {
-            if (loadJvmtiException instanceof IOException) {
-                throw (IOException)loadJvmtiException;
-            } else {
-                throw new IOException("Could not load jvmti plugin",
-                        loadJvmtiException);
-            }
-        }
-
+        Debug.attachJvmtiAgent(AGENT_LIB_NAME, null, cl);
         nativeRegisterTransformerHook();
     }
 


### PR DESCRIPTION
Use the Android P preview SDK that contains the Debug.attachJvmtiAgent
method.

There is still no API level defined for P, hence we still have to check
Build.VERSION.CODENAME.equals("P")