### PR TITLE
Issue #77: Switch to mockito 2.16

### DIFF
--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -28,6 +28,6 @@ repositories {
 
 dependencies {
     compile project(':dexmaker')
-    compile 'org.mockito:mockito-core:2.15.0', { exclude group: "net.bytebuddy" }
+    compile 'org.mockito:mockito-core:2.16.0', { exclude group: "net.bytebuddy" }
 }
 

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -14,5 +14,5 @@ repositories {
 dependencies {
     compile project(":dexmaker")
 
-    compile 'org.mockito:mockito-core:2.15.0', { exclude group: "net.bytebuddy" }
+    compile 'org.mockito:mockito-core:2.16.0', { exclude group: "net.bytebuddy" }
 }


### PR DESCRIPTION
among other improvements this fixed a severe memory leak for -inline
mockmakers. This memory leak made running more than a couple hundret
tests at once impossible on Android.

With the Android P SDK released and this memory leak fixed I think
dexmaker-mockito-inline is ready for publishing.