### PR TITLE
Improve build files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,13 @@ import com.linkedin.gradle.DistributeTask
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.0"
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.7.0"
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,9 +11,12 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    compile 'org.ajoberstar:gradle-git:1.2.0'
-    compile group: 'org.apache.httpcomponents', name: 'fluent-hc', version: '4.5.2'
-    compile('org.jfrog.buildinfo:build-info-extractor-gradle:4.4.0') {
+    // Force guava 22 otherwise the dependency of org.jfrog.buildinfo:build-info-extractor-gradle
+    // (guava 18) is loaded before com.android.tools.build:grade can force at least 22
+    implementation 'com.google.guava:guava:23.0'
+
+    implementation group: 'org.apache.httpcomponents', name: 'fluent-hc', version: '4.5.5'
+    implementation('org.jfrog.buildinfo:build-info-extractor-gradle:4.7.0') {
         exclude module: 'groovy-all'
     }
 }

--- a/dexmaker-mockito-inline-dispatcher/build.gradle
+++ b/dexmaker-mockito-inline-dispatcher/build.gradle
@@ -1,17 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     lintOptions {
         abortOnError false
     }
 
     defaultConfig {
-        applicationId "com.android.dexmaker.mockito.inline.dispatcher"
-        minSdkVersion 25
-        targetSdkVersion 25
+        applicationId 'com.android.dexmaker.mockito.inline.dispatcher'
+        minSdkVersion 27
+        targetSdkVersion 27
         versionName VERSION_NAME
     }
 }

--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -2,19 +2,19 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 'android-P'
-    buildToolsVersion "25.0.0"
+    buildToolsVersion '27.0.3'
 
     lintOptions {
         abortOnError false
     }
 
     defaultConfig {
-        applicationId "com.android.dexmaker.mockito.inline.tests"
-        minSdkVersion 25
-        targetSdkVersion 25
+        applicationId 'com.android.dexmaker.mockito.inline.tests'
+        minSdkVersion 27
+        targetSdkVersion 27
         versionName VERSION_NAME
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     externalNativeBuild {
@@ -31,6 +31,8 @@ repositories {
 
 dependencies {
     androidTestCompile project(':dexmaker-mockito-inline')
+
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile 'com.android.support.test:runner:1.0.1'
+    androidTestCompile 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -2,15 +2,15 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 'android-P'
-    buildToolsVersion "25.0.0"
+    buildToolsVersion '27.0.3'
 
     lintOptions {
         abortOnError false
     }
 
     defaultConfig {
-        minSdkVersion 25
-        targetSdkVersion 25
+        minSdkVersion 27
+        targetSdkVersion 27
         versionName VERSION_NAME
     }
 
@@ -19,7 +19,6 @@ android {
             path 'CMakeLists.txt'
         }
     }
-
 }
 
 repositories {
@@ -27,7 +26,8 @@ repositories {
 }
 
 dependencies {
-    compile project(':dexmaker')
-    compile 'org.mockito:mockito-core:2.16.0', { exclude group: "net.bytebuddy" }
+    implementation project(':dexmaker')
+
+    implementation 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
 }
 

--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -1,20 +1,20 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     lintOptions {
         abortOnError false
     }
 
     defaultConfig {
-        applicationId "com.android.dexmaker.mockito.tests"
-        minSdkVersion 25
-        targetSdkVersion 25
+        applicationId 'com.android.dexmaker.mockito.tests'
+        minSdkVersion 8
+        targetSdkVersion 27
         versionName VERSION_NAME
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 }
 
@@ -24,9 +24,9 @@ repositories {
 }
 
 dependencies {
-    compile project(':dexmaker')
-    compile project(':dexmaker-mockito')
+    androidTestCompile project(':dexmaker-mockito')
 
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'junit:junit:4.12'
+    androidTestCompile 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -24,9 +24,9 @@ repositories {
 }
 
 dependencies {
-    androidTestCompile project(':dexmaker-mockito')
+    androidTestImplementation project(':dexmaker-mockito')
 
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
+    androidTestImplementation 'com.android.support.test:runner:0.5'
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile project(":dexmaker")
+    implementation project(':dexmaker')
 
-    compile 'org.mockito:mockito-core:2.16.0', { exclude group: "net.bytebuddy" }
+    implementation 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-tests/build.gradle
+++ b/dexmaker-tests/build.gradle
@@ -1,28 +1,28 @@
 apply plugin: 'com.android.application'
 
+android {
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
+
+    defaultConfig {
+        applicationId 'com.linkedin.dexmaker'
+        minSdkVersion 8
+        targetSdkVersion 27
+        versionCode 1
+        versionName VERSION_NAME
+
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+    }
+}
+
 repositories {
     jcenter()
     google()
 }
 
-android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.0'
-
-    defaultConfig {
-        applicationId "com.linkedin.dexmaker"
-        minSdkVersion 8
-        targetSdkVersion 25
-        versionCode 1
-        versionName VERSION_NAME
-
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-}
-
 dependencies {
-    compile project(":dexmaker")
+    implementation project(":dexmaker")
 
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:0.5'
+    androidTestImplementation 'junit:junit:4.12'
 }

--- a/dexmaker/build.gradle
+++ b/dexmaker/build.gradle
@@ -12,5 +12,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.jakewharton.android.repackaged:dalvik-dx:7.1.0_r7'
+    implementation 'com.jakewharton.android.repackaged:dalvik-dx:7.1.0_r7'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 org.gradle.jvmargs=-Djava.awt.headless=true
+org.gradle.parallel=true
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
- newest version of all dependencies (including gradle 3)
   This required me to do the nasty guava hack in buildSrc/build.gradle.
   This seems to be a known quirk with gradle and this was the
   recommended workaround
- Consistent format of build files
- Parallel build (cuts build time in half)