### PR TITLE
Enable error prone on all dexmaker projects

### DIFF
--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+    }
+}
+
+apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.application'
 
 android {
@@ -30,9 +42,9 @@ repositories {
 }
 
 dependencies {
-    androidTestCompile project(':dexmaker-mockito-inline')
+    androidTestImplementation project(':dexmaker-mockito-inline')
 
-    androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support.test:runner:1.0.1'
-    androidTestCompile 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+    }
+}
+
+apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.library'
 
 android {
@@ -19,6 +31,10 @@ android {
             path 'CMakeLists.txt'
         }
     }
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs += ["-Xep:StringSplitter:OFF"]
 }
 
 repositories {

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InlineDexmakerMockMaker.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InlineDexmakerMockMaker.java
@@ -388,6 +388,7 @@ public final class InlineDexmakerMockMaker implements MockMaker {
             return adapters.isEmpty();
         }
 
+        @SuppressWarnings("CollectionIncompatibleType")
         @Override
         public boolean containsKey(Object mock) {
             synchronized (lock) {
@@ -406,6 +407,7 @@ public final class InlineDexmakerMockMaker implements MockMaker {
             }
         }
 
+        @SuppressWarnings("CollectionIncompatibleType")
         @Override
         public InvocationHandlerAdapter get(Object mock) {
             synchronized (lock) {
@@ -468,6 +470,7 @@ public final class InlineDexmakerMockMaker implements MockMaker {
             }
         }
 
+        @SuppressWarnings("CollectionIncompatibleType")
         @Override
         public InvocationHandlerAdapter remove(Object mock) {
             synchronized (lock) {

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMethodAdvice.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMethodAdvice.java
@@ -24,6 +24,7 @@ class MockMethodAdvice {
     /** Pattern to decompose a instrumentedMethodWithTypeAndSignature */
     private final Pattern methodPattern = Pattern.compile("(.*)#(.*)\\((.*)\\)");
 
+    @SuppressWarnings("ThreadLocalUsage")
     private final SelfCallInfo selfCallInfo = new SelfCallInfo();
 
     MockMethodAdvice(Map<Object, InvocationHandlerAdapter> interceptors) {

--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+    }
+}
+
+apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.application'
 
 android {

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+    }
+}
+
+apply plugin: "net.ltgt.errorprone"
 apply plugin: 'java'
 apply from: "$rootDir/gradle/publishing.gradle"
 

--- a/dexmaker-tests/build.gradle
+++ b/dexmaker-tests/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+    }
+}
+
+apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.application'
 
 android {

--- a/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
+++ b/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
@@ -202,6 +202,7 @@ public class ProxyBuilderTest {
         }
     }
 
+    @Test
     public void testProxyingPackagePrivateMethods_NotIntercepted()
             throws Throwable {
         HasPackagePrivateMethod proxy = proxyFor(HasPackagePrivateMethod.class)
@@ -215,10 +216,10 @@ public class ProxyBuilderTest {
 
         try {
             proxy.result();
-            fail();
         } catch (AssertionFailedError expected) {
-
+            return;
         }
+        fail();
     }
 
     public static class HasProtectedMethod {
@@ -271,7 +272,7 @@ public class ProxyBuilderTest {
     }
 
     @Test
-    @SuppressWarnings("EqualsWithItself")
+    @SuppressWarnings({"EqualsWithItself", "SelfEquals"})
     public void testObjectMethodsAreAlsoProxied() throws Throwable {
         Object proxy = proxyFor(Object.class).build();
         fakeHandler.setFakeResult("mystring");
@@ -335,6 +336,7 @@ public class ProxyBuilderTest {
     }
 
     public static class InvokeSuperHandler implements InvocationHandler {
+        @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             return ProxyBuilder.callSuper(proxy, method, args);
         }
@@ -405,6 +407,7 @@ public class ProxyBuilderTest {
     @Test
     public void testSinglePrimitiveParameter() throws Throwable {
         InvocationHandler handler = new InvocationHandler() {
+            @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                 return "asdf" + ((Integer) args[0]).intValue();
             }
@@ -486,6 +489,7 @@ public class ProxyBuilderTest {
     @Test
     public void testSometimesDelegateToSuper() throws Exception {
         InvocationHandler delegatesOddValues = new InvocationHandler() {
+            @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                 if (method.getName().equals("method")) {
                     int intValue = ((Integer) args[0]).intValue();
@@ -508,6 +512,7 @@ public class ProxyBuilderTest {
     @Test
     public void testCallSuperThrows() throws Exception {
         InvocationHandler handler = new InvocationHandler() {
+            @Override
             public Object invoke(Object o, Method method, Object[] objects) throws Throwable {
                 return ProxyBuilder.callSuper(o, method, objects);
             }
@@ -616,10 +621,11 @@ public class ProxyBuilderTest {
         }
         try {
             proxyFor(CtorHasError.class).build();
-            fail();
         } catch (Error expected) {
             assertEquals("my message again", expected.getMessage());
+            return;
         }
+        fail();
     }
 
     @Test
@@ -771,6 +777,7 @@ public class ProxyBuilderTest {
     @Test
     public void testImplementInterfaceCallingThroughConcreteClass() throws Throwable {
         InvocationHandler invocationHandler = new InvocationHandler() {
+            @Override
             public Object invoke(Object o, Method method, Object[] objects) throws Throwable {
                 assertEquals("a", ProxyBuilder.callSuper(o, method, objects));
                 return "b";
@@ -796,6 +803,7 @@ public class ProxyBuilderTest {
         final AtomicInteger count = new AtomicInteger();
 
         InvocationHandler invocationHandler = new InvocationHandler() {
+            @Override
             public Object invoke(Object o, Method method, Object[] objects) throws Throwable {
                 count.incrementAndGet();
                 return ProxyBuilder.callSuper(o, method, objects);
@@ -817,6 +825,7 @@ public class ProxyBuilderTest {
     }
 
     public static class ImplementsCallable implements Callable<String> {
+        @Override
         public String call() throws Exception {
             return "a";
         }
@@ -831,6 +840,7 @@ public class ProxyBuilderTest {
     @Test
     public void testInterfacesSameNamesDifferentReturnTypes() throws Throwable {
         InvocationHandler handler = new InvocationHandler() {
+            @Override
             public Object invoke(Object o, Method method, Object[] objects) throws Throwable {
                 if (method.getReturnType() == void.class) {
                     return null;
@@ -974,6 +984,7 @@ public class ProxyBuilderTest {
     private static class FakeInvocationHandler implements InvocationHandler {
         private Object fakeResult = "fake result";
 
+        @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             return fakeResult;
         }
@@ -1077,6 +1088,7 @@ public class ProxyBuilderTest {
     }
 
     public static class ConcreteClassA implements FooReturnsInt {
+        @Override
         // from FooReturnsInt
         public int foo() {
             return 1;
@@ -1089,6 +1101,7 @@ public class ProxyBuilderTest {
     }
 
     public static class ConcreteClassB implements FooReturnsInt {
+        @Override
         // from FooReturnsInt
         public int foo() {
             return 0;
@@ -1150,6 +1163,7 @@ public class ProxyBuilderTest {
         }
 
         InvocationHandler handler = new InvokeSuperHandler() {
+            @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                 if (method.getName().equals("returnA")) {
                     return "fake A";

--- a/dexmaker/build.gradle
+++ b/dexmaker/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+    }
+}
+
+apply plugin: "net.ltgt.errorprone"
 apply plugin: 'java'
 apply from: "$rootDir/gradle/publishing.gradle"
 
@@ -9,6 +21,10 @@ sourceCompatibility = '1.7'
 
 repositories {
     jcenter()
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs += ["-Xep:StringSplitter:OFF"]
 }
 
 dependencies {

--- a/dexmaker/src/main/java/com/android/dx/AnnotationId.java
+++ b/dexmaker/src/main/java/com/android/dx/AnnotationId.java
@@ -130,7 +130,7 @@ public final class AnnotationId<D, V> {
             throw new IllegalStateException("This annotation is not for method");
         }
 
-        if (method.declaringType != declaringType) {
+        if (!method.declaringType.equals(declaringType)) {
             throw new IllegalArgumentException("Method" + method + "'s declaring type is inconsistent with" + this);
         }
 


### PR DESCRIPTION
@awesdroid Beside some small test fixed the only real issue found was the comparison in AnnotationId#addToMethod. I think it is right to use equals() here.

