### PR TITLE
Set up dexmaker-mockito-inline for publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ artifactory {
         }
 
         defaults {
-            publications 'lib', 'ivyJava'
+            publications 'lib', 'ivyJava', 'ivyLib'
         }
 
         publishArtifacts = true
@@ -45,5 +45,5 @@ artifactory {
 }
 
 task distributeBuild(type: DistributeTask) {
-    dependsOn ':artifactoryPublish', 'dexmaker:artifactoryPublish', 'dexmaker-mockito:artifactoryPublish'
+    dependsOn ':artifactoryPublish', 'dexmaker:artifactoryPublish', 'dexmaker-mockito:artifactoryPublish', 'dexmaker-mockito-inline:artifactoryPublish'
 }

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -11,6 +11,11 @@ buildscript {
 
 apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.library'
+apply plugin: 'maven-publish'
+apply plugin: 'ivy-publish'
+apply plugin: 'com.jfrog.artifactory'
+
+version = VERSION_NAME
 
 android {
     compileSdkVersion 'android-P'
@@ -35,6 +40,66 @@ android {
 
 tasks.withType(JavaCompile) {
     options.compilerArgs += ["-Xep:StringSplitter:OFF"]
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+publishing {
+    publications {
+        ivyLib(IvyPublication) {
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.implementation.getAllDependencies())
+          artifact sourcesJar
+          artifact javadocJar
+        }
+
+        lib(MavenPublication) {
+          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.implementation.getAllDependencies())
+
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom.withXml {
+                asNode().children().last() + {
+                    resolveStrategy = Closure.DELEGATE_FIRST
+                    description = 'Implementation of the Mockito Inline API for use on the Android Dalvik VM'
+                    url 'https://github.com/linkedin/dexmaker'
+                    scm {
+                        url 'https://github.com/linkedin/dexmaker'
+                        connection 'scm:git:git://github.com/linkedin/dexmaker.git'
+                        developerConnection 'https://github.com/linkedin/dexmaker.git'
+                    }
+                    licenses {
+                        license {
+                            name 'The Apache Software License, Version 2.0'
+                            url 'http://www.apache.org/license/LICENSE-2.0.txt'
+                            distribution 'repo'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id 'com.linkedin'
+                            name 'LinkedIn Corp'
+                            email ''
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 repositories {


### PR DESCRIPTION
Since this artifact publishes an aar file instead
of a jar, we can't reuse publishing.gradle directly.
We could later improve the publishing scripts so
there isn't so much duplication, but for now this
should be enough to get the new artifact published.

Tested this change by running :dexmaker-mockito-inline:publishToMavenLocal
and checking that the generated pom file included the
proper dependencies. Also created a sample Android app
and verified that I can depend on this artifact via
mavenLocal() and could successfully write a test that
mocks a final class / method.