### PR TITLE
Set minSdkVersion 1 for dexmaker-mockito-inline

### DIFF
--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -26,7 +26,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 27
+        minSdkVersion 1
         targetSdkVersion 27
         versionName VERSION_NAME
     }


### PR DESCRIPTION
This library really requires Android P to run, but it seems
more useful to consumers to set minSdkVersion = 1. The
library already checks that it is running on Android P as
the first action it performs, and fails immediately if it's
running on an older API level, so it doesn't matter that
we're using other APIs which aren't supported back to API 1.

The reason this is useful is that consumers may use any API
level they want as their minSdkVersion but still only run
their tests on Android P or above. The minSdkVersion of
dexmaker-mockito-inline shouldn't prevent them from using
this workflow if they so desire.