### PR TITLE
Fix error prone warning for dexmaker-tests and dexmaker-mockito-tests

### DIFF
--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -34,7 +34,8 @@ repositories {
 dependencies {
     androidTestImplementation project(':dexmaker-mockito')
 
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    //noinspection GradleDependency
+    androidTestImplementation 'com.android.support.test:runner:0.5'
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-tests/build.gradle
+++ b/dexmaker-tests/build.gradle
@@ -35,6 +35,7 @@ repositories {
 dependencies {
     implementation project(":dexmaker")
 
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    //noinspection GradleDependency
+    androidTestImplementation 'com.android.support.test:runner:0.5'
     androidTestImplementation 'junit:junit:4.12'
 }

--- a/dexmaker-tests/src/androidTest/java/com/android/dx/AppDataDirGuesserTest.java
+++ b/dexmaker-tests/src/androidTest/java/com/android/dx/AppDataDirGuesserTest.java
@@ -129,6 +129,7 @@ public final class AppDataDirGuesserTest {
     private TestCondition guessCacheDirFor(final String path) {
         final Set<String> notWriteable = new HashSet<>();
         return new TestCondition() {
+            @Override
             public void shouldGive(String... files) {
                 AppDataDirGuesser guesser = new AppDataDirGuesser() {
                     @Override
@@ -148,6 +149,7 @@ public final class AppDataDirGuesserTest {
                 }
             }
 
+            @Override
             public TestCondition withNonWriteable(String... files) {
                 notWriteable.addAll(Arrays.asList(files));
                 return this;

--- a/dexmaker-tests/src/androidTest/java/com/android/dx/DexMakerTest.java
+++ b/dexmaker-tests/src/androidTest/java/com/android/dx/DexMakerTest.java
@@ -135,7 +135,7 @@ public final class DexMakerTest {
         addDefaultConstructor();
 
         Class<?> generatedClass = generateAndLoad();
-        Object instance = generatedClass.newInstance();
+        Object instance = generatedClass.getDeclaredConstructor().newInstance();
         Method method = generatedClass.getMethod("call");
         method.invoke(instance);
     }
@@ -177,7 +177,7 @@ public final class DexMakerTest {
         addDefaultConstructor();
 
         Class<?> generatedClass = generateAndLoad();
-        Object instance = generatedClass.newInstance();
+        Object instance = generatedClass.getDeclaredConstructor().newInstance();
         Method method = generatedClass.getMethod("call", int.class);
         method.invoke(instance, 0);
     }
@@ -244,7 +244,7 @@ public final class DexMakerTest {
         addDefaultConstructor();
 
         Class<?> generatedClass = generateAndLoad();
-        Object instance = generatedClass.newInstance();
+        Object instance = generatedClass.getDeclaredConstructor().newInstance();
         Method method = generatedClass.getMethod("call", generatedClass);
         assertEquals(5, method.invoke(null, instance));
     }
@@ -278,7 +278,7 @@ public final class DexMakerTest {
         addDefaultConstructor();
 
         Class<?> generatedClass = generateAndLoad();
-        Object instance = generatedClass.newInstance();
+        Object instance = generatedClass.getDeclaredConstructor().newInstance();
         Method method = generatedClass.getMethod("superHashCode");
         assertEquals(System.identityHashCode(instance), method.invoke(instance));
     }
@@ -299,6 +299,7 @@ public final class DexMakerTest {
         code.returnValue(localResult);
 
         Callable<Object> callable = new Callable<Object>() {
+            @Override
             public Object call() throws Exception {
                 return "abc";
             }
@@ -425,7 +426,7 @@ public final class DexMakerTest {
         addDefaultConstructor();
 
         Class<?> generatedClass = generateAndLoad();
-        Object instance = generatedClass.newInstance();
+        Object instance = generatedClass.getDeclaredConstructor().newInstance();
 
         Field a = generatedClass.getField("a");
         assertEquals(int.class, a.getType());
@@ -691,6 +692,7 @@ public final class DexMakerTest {
     }
 
     @Test
+    @SuppressWarnings("FloatingPointLiteralPrecision")
     public void testCastFloatingPointToInteger() throws Exception {
         Method floatToInt = numericCastingMethod(float.class, int.class);
         assertEquals(0, floatToInt.invoke(null, 0.0f));
@@ -1046,7 +1048,7 @@ public final class DexMakerTest {
         assertEquals((short) 0x1234, instance.shortValue);
     }
 
-    public class Instance {
+    public static class Instance {
         public int intValue;
         public long longValue;
         public float floatValue;
@@ -1871,7 +1873,7 @@ public final class DexMakerTest {
         addDefaultConstructor();
 
         Class<?> generatedClass = generateAndLoad();
-        Object instance = generatedClass.newInstance();
+        Object instance = generatedClass.getDeclaredConstructor().newInstance();
         Method method = generatedClass.getMethod("call");
         assertTrue(Modifier.isSynchronized(method.getModifiers()));
         try {
@@ -1905,7 +1907,7 @@ public final class DexMakerTest {
         addDefaultConstructor();
 
         Class<?> generatedClass = generateAndLoad();
-        Object instance = generatedClass.newInstance();
+        Object instance = generatedClass.getDeclaredConstructor().newInstance();
         Method method = generatedClass.getMethod("call");
         assertFalse(Modifier.isSynchronized(method.getModifiers()));
         method.invoke(instance); // will take 100ms
@@ -2121,7 +2123,7 @@ public final class DexMakerTest {
         TypeId<IllegalStateException> iseType = TypeId.get(IllegalStateException.class);
         Local<IllegalStateException> localIse = code.newLocal(iseType);
         if (params.length > 0) {
-            if (params[0] == typeId) {
+            if (params[0].equals(typeId)) {
                 Local<?> localResult = code.getParameter(0, TypeId.INT);
                 code.returnValue(localResult);
             } else {
@@ -2188,6 +2190,7 @@ public final class DexMakerTest {
 
     private File[] getJarFiles() {
         return getDataDirectory().listFiles(new FilenameFilter() {
+            @Override
             public boolean accept(File dir, String name) {
                 return name.endsWith(".jar");
             }


### PR DESCRIPTION
- Also revert to com.android.support.test:runner:0.5 as more modern
  versions required minSDK 9