### PR TITLE
 Issue #97: Add stubbing of static methods

### DIFF
--- a/dexmaker-mockito-inline-extended-tests/CMakeLists.txt
+++ b/dexmaker-mockito-inline-extended-tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.4.1)
+
+set(slicer_sources
+    ../dexmaker-mockito-inline/external/slicer/bytecode_encoder.cc
+    ../dexmaker-mockito-inline/external/slicer/code_ir.cc
+    ../dexmaker-mockito-inline/external/slicer/common.cc
+    ../dexmaker-mockito-inline/external/slicer/control_flow_graph.cc
+    ../dexmaker-mockito-inline/external/slicer/debuginfo_encoder.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_bytecode.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_format.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_ir_builder.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_ir.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_utf8.cc
+    ../dexmaker-mockito-inline/external/slicer/instrumentation.cc
+    ../dexmaker-mockito-inline/external/slicer/reader.cc
+    ../dexmaker-mockito-inline/external/slicer/tryblocks_encoder.cc
+    ../dexmaker-mockito-inline/external/slicer/writer.cc)
+
+add_library(slicer
+            STATIC
+            ${slicer_sources})
+
+include_directories(../dexmaker-mockito-inline/external/jdk ../dexmaker-mockito-inline/external/slicer/export/)
+
+target_link_libraries(slicer z)
+
+add_library(multiplejvmtiagentsinterferenceagent
+            SHARED
+            ../dexmaker-mockito-inline-tests/src/main/jni/multiplejvmtiagentsinterferenceagent/agent.cc)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -frtti -Wall -Werror -Wno-unused-parameter -Wno-shift-count-overflow -Wno-error=non-virtual-dtor -Wno-sign-compare -Wno-switch -Wno-missing-braces")
+
+target_link_libraries(multiplejvmtiagentsinterferenceagent slicer)

--- a/dexmaker-mockito-inline-extended-tests/build.gradle
+++ b/dexmaker-mockito-inline-extended-tests/build.gradle
@@ -1,0 +1,50 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+    }
+}
+
+apply plugin: "net.ltgt.errorprone"
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 'android-P'
+    buildToolsVersion '27.0.3'
+
+    defaultConfig {
+        applicationId 'com.android.dexmaker.mockito.inline.extended.tests'
+        minSdkVersion 27
+        targetSdkVersion 27
+        versionName VERSION_NAME
+
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+    }
+
+    externalNativeBuild {
+        cmake {
+            path 'CMakeLists.txt'
+        }
+    }
+    compileOptions {
+        targetCompatibility 1.8
+        sourceCompatibility 1.8
+    }
+}
+
+repositories {
+    jcenter()
+    google()
+}
+
+dependencies {
+    androidTestImplementation project(':dexmaker-mockito-inline-extended')
+
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
+}

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockInstanceUsingExtendedMockito.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockInstanceUsingExtendedMockito.java
@@ -16,9 +16,13 @@
 
 package com.android.dx.mockito.inline.extended.tests;
 
+import com.android.dx.mockito.inline.extended.StaticMockitoSession;
+
 import org.junit.Test;
+import org.mockito.Mock;
 
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.mock;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockitoSession;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.verify;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.when;
 import static org.junit.Assert.assertEquals;
@@ -26,6 +30,9 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 
 public class MockInstanceUsingExtendedMockito {
+    @Mock
+    private TestClass mockField;
+
     public static class TestClass {
         public String echo(String arg) {
             return arg;
@@ -42,5 +49,20 @@ public class MockInstanceUsingExtendedMockito {
         assertEquals("B", t.echo("stubbed"));
         verify(t).echo("mocked");
         verify(t).echo("stubbed");
+    }
+
+    @Test
+    public void useMockitoSession() throws Exception {
+        StaticMockitoSession session = mockitoSession().initMocks(this).startMocking();
+        try {
+            assertNull(mockField.echo("mocked"));
+
+            when(mockField.echo(eq("stubbed"))).thenReturn("B");
+            assertEquals("B", mockField.echo("stubbed"));
+            verify(mockField).echo("mocked");
+            verify(mockField).echo("stubbed");
+        } finally {
+            session.finishMocking();
+        }
     }
 }

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockInstanceUsingExtendedMockito.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockInstanceUsingExtendedMockito.java
@@ -16,6 +16,8 @@
 
 package com.android.dx.mockito.inline.extended.tests;
 
+import com.android.dx.mockito.inline.extended.ExtendedMockito;
+import com.android.dx.mockito.inline.extended.StaticInOrder;
 import com.android.dx.mockito.inline.extended.StaticMockitoSession;
 
 import org.junit.Test;
@@ -65,6 +67,20 @@ public class MockInstanceUsingExtendedMockito {
         } finally {
             session.finishMocking();
         }
+    }
+
+    @Test
+    public void verifyInOrder() throws Exception {
+        TestClass t = mock(TestClass.class);
+
+        assertNull(t.echo("mocked"));
+
+        when(t.echo(eq("stubbed"))).thenReturn("B");
+        assertEquals("B", t.echo("stubbed"));
+
+        StaticInOrder inOrder = ExtendedMockito.inOrder(t);
+        inOrder.verify(t).echo("mocked");
+        inOrder.verify(t).echo("stubbed");
     }
 
     @Test

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockInstanceUsingExtendedMockito.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockInstanceUsingExtendedMockito.java
@@ -21,6 +21,7 @@ import com.android.dx.mockito.inline.extended.StaticMockitoSession;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.doReturn;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.mock;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockitoSession;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.verify;
@@ -64,5 +65,17 @@ public class MockInstanceUsingExtendedMockito {
         } finally {
             session.finishMocking();
         }
+    }
+
+    @Test
+    public void mockClassUsingDoReturn() throws Exception {
+        TestClass t = mock(TestClass.class);
+
+        assertNull(t.echo("mocked"));
+
+        doReturn("B").when(t).echo(eq("stubbed"));
+        assertEquals("B", t.echo("stubbed"));
+        verify(t).echo("mocked");
+        verify(t).echo("stubbed");
     }
 }

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockInstanceUsingExtendedMockito.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockInstanceUsingExtendedMockito.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended.tests;
+
+import org.junit.Test;
+
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.mock;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.verify;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.when;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class MockInstanceUsingExtendedMockito {
+    public static class TestClass {
+        public String echo(String arg) {
+            return arg;
+        }
+    }
+
+    @Test
+    public void mockClass() throws Exception {
+        TestClass t = mock(TestClass.class);
+
+        assertNull(t.echo("mocked"));
+
+        when(t.echo(eq("stubbed"))).thenReturn("B");
+        assertEquals("B", t.echo("stubbed"));
+        verify(t).echo("mocked");
+        verify(t).echo("stubbed");
+    }
+}

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/StaticMockitoSession.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/StaticMockitoSession.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended.tests;
+
+import android.content.ContentResolver;
+import android.provider.Settings;
+
+import org.junit.Test;
+import org.mockito.MockitoSession;
+import org.mockito.exceptions.misusing.UnnecessaryStubbingException;
+import org.mockito.quality.Strictness;
+
+import static android.provider.Settings.Global.DEVICE_NAME;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.doReturn;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockitoSession;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class StaticMockitoSession {
+    @Test
+    public void strictUnnecessaryStubbing() throws Exception {
+        MockitoSession session = mockitoSession().spyStatic(Settings.Global.class).startMocking();
+
+        // Set up unnecessary stubbing
+        doReturn("23").when(() -> Settings.Global.getString(any
+                (ContentResolver.class), eq(DEVICE_NAME)));
+
+        try {
+            session.finishMocking();
+            fail();
+        } catch (UnnecessaryStubbingException e) {
+            assertTrue("\"" + e.getMessage() + "\" does not contain 'Settings$Global.getString'",
+                    e.getMessage().contains("Settings$Global.getString"));
+        }
+    }
+
+    @Test
+    public void lenientUnnecessaryStubbing() throws Exception {
+        MockitoSession session = mockitoSession().strictness(Strictness.LENIENT)
+                .spyStatic(Settings.Global.class).startMocking();
+
+        // Set up unnecessary stubbing
+        doReturn("23").when(() -> Settings.Global.getString(any
+                (ContentResolver.class), eq(DEVICE_NAME)));
+
+        session.finishMocking();
+    }
+}

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/StaticMockitoSessionVsMockitoJUnitRunner.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/StaticMockitoSessionVsMockitoJUnitRunner.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended.tests;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StaticMockitoSessionVsMockitoJUnitRunner {
+    @Test
+    public void simpleStubbing() throws Exception {
+        (new MockStatic()).spyStatic();
+    }
+}

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/Stress.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/Stress.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended.tests;
+
+import android.util.Log;
+
+import org.junit.Test;
+import org.mockito.MockitoSession;
+
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockitoSession;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.staticMockMarker;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.reset;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+public class Stress {
+    private static final String LOG_TAG = Stress.class.getSimpleName();
+
+    private static class SuperClass {
+        static String returnB() {
+            return "superB";
+        }
+
+        final static String returnD() {
+            return "superD";
+        }
+    }
+
+    @Test
+    public void stressFinalStaticMethod() throws Exception {
+        MockitoSession session = mockitoSession().mockStatic(SuperClass.class).startMocking();
+        try {
+            assertNull(SuperClass.returnD());
+
+            for (int i = 0; i < 1000; i++) {
+                when(SuperClass.returnD()).thenReturn("fakeD");
+                assertEquals("fakeD", SuperClass.returnD());
+
+                reset(staticMockMarker(SuperClass.class));
+                assertNull(SuperClass.returnD());
+
+                if (i % 100 == 0) {
+                    Log.i(LOG_TAG, "Ran " + i + " tests");
+                }
+            }
+        } finally {
+            session.finishMocking();
+        }
+    }
+
+    @Test
+    public void stressStaticMethod() throws Exception {
+        MockitoSession session = mockitoSession().mockStatic(SuperClass.class).startMocking();
+        try {
+            assertNull(SuperClass.returnB());
+
+            for (int i = 0; i < 10; i++) {
+                when(SuperClass.returnB()).thenReturn("fakeB");
+                assertEquals("fakeB", SuperClass.returnB());
+
+                reset(staticMockMarker(SuperClass.class));
+                assertNull(SuperClass.returnB());
+
+                Log.i(LOG_TAG, "Ran " + i + " tests");
+            }
+        } finally {
+            session.finishMocking();
+        }
+    }
+
+}

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/Stress.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/Stress.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
+
 public class Stress {
     private static final String LOG_TAG = Stress.class.getSimpleName();
 

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/VerifyStatic.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/VerifyStatic.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended.tests;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockitoSession;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
+
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.ignoreStubs;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockitoSession;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.staticMockMarker;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.verify;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.verifyNoMoreInteractions;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.verifyZeroInteractions;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.when;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class VerifyStatic {
+    @Test
+    public void verifyMockedStringMethod() throws Exception {
+        MockitoSession session = mockitoSession().mockStatic(EchoClass.class).startMocking();
+        try {
+            assertNull(EchoClass.echo("marco!"));
+
+            ArgumentCaptor<String> echoCaptor = ArgumentCaptor.forClass(String.class);
+            verify(() -> {return EchoClass.echo(echoCaptor.capture());});
+            assertEquals("marco!", echoCaptor.getValue());
+
+            verifyNoMoreInteractions(staticMockMarker(EchoClass.class));
+        } finally {
+            session.finishMocking();
+        }
+    }
+
+    @Test
+    public void verifyMockedVoidMethod() throws Exception {
+        MockitoSession session = mockitoSession().mockStatic(ConsumeClass.class).startMocking();
+        try {
+            ConsumeClass.consume("donut");
+
+            ArgumentCaptor<String> yumCaptor = ArgumentCaptor.forClass(String.class);
+            verify(() -> ConsumeClass.consume(yumCaptor.capture()));
+
+            verifyNoMoreInteractions(staticMockMarker(ConsumeClass.class));
+        } finally {
+            session.finishMocking();
+        }
+    }
+
+    @Test
+    public void verifyWithTwoMocks() throws Exception {
+        MockitoSession session = mockitoSession().mockStatic(EchoClass.class)
+                .mockStatic(ConsumeClass.class).startMocking();
+        try {
+            ConsumeClass.consume("donut");
+            assertNull(EchoClass.echo("marco!"));
+
+            ArgumentCaptor<String> yumCaptor = ArgumentCaptor.forClass(String.class);
+            verify(() -> ConsumeClass.consume(yumCaptor.capture()));
+
+            ArgumentCaptor<String> echoCaptor = ArgumentCaptor.forClass(String.class);
+            verify(() -> {return EchoClass.echo(echoCaptor.capture());});
+            assertEquals("marco!", echoCaptor.getValue());
+
+            verifyNoMoreInteractions(staticMockMarker(ConsumeClass.class));
+        } finally {
+            session.finishMocking();
+        }
+    }
+
+    @Test
+    public void verifySpiedStringMethod() throws Exception {
+        MockitoSession session = mockitoSession().spyStatic(EchoClass.class).startMocking();
+        try {
+            assertEquals("marco!", EchoClass.echo("marco!"));
+
+            ArgumentCaptor<String> echoCaptor = ArgumentCaptor.forClass(String.class);
+            verify(() -> {return EchoClass.echo(echoCaptor.capture());});
+            assertEquals("marco!", echoCaptor.getValue());
+
+            verifyNoMoreInteractions(staticMockMarker(EchoClass.class));
+        } finally {
+            session.finishMocking();
+        }
+    }
+
+    @Test(expected = NoInteractionsWanted.class)
+    public void zeroInvocationsThrowsIfThereWasAnInvocation() throws Exception {
+        MockitoSession session = mockitoSession().mockStatic(EchoClass.class).startMocking();
+        try {
+            EchoClass.echo("marco!");
+            verifyZeroInteractions(staticMockMarker(EchoClass.class));
+            fail();
+        } finally {
+            session.finishMocking();
+        }
+    }
+
+    @Test
+    public void verifyWithIgnoreStubs() throws Exception {
+        MockitoSession session = mockitoSession().spyStatic(EchoClass.class).startMocking();
+        try {
+            // 'ignoreStubs' only ignore stubs
+            when(EchoClass.echo("marco!")).thenReturn("polo");
+            assertEquals("polo", EchoClass.echo("marco!"));
+            assertEquals("echo", EchoClass.echo("echo"));
+
+            verify(() -> {return EchoClass.echo(eq("echo"));});
+            verifyNoMoreInteractions(ignoreStubs(staticMockMarker(EchoClass.class)));
+        } finally {
+            session.finishMocking();
+        }
+    }
+
+    private static class EchoClass {
+        static final String echo(String echo) {
+            return echo;
+        }
+    }
+
+    private static class ConsumeClass {
+        static final void consume(String yum) {
+            // empty
+        }
+    }
+}

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/tests
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/tests
@@ -1,0 +1,1 @@
+../../../../../../../../../dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/tests
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/tests
@@ -1,0 +1,1 @@
+../../../../../../../../dexmaker-mockito-tests/src/androidTest/java/com/android/dx/mockito/tests

--- a/dexmaker-mockito-inline-extended-tests/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-inline-extended-tests/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest package="com.android.dexmaker.mockito.inline.extended.tests">
+    <application />
+</manifest>

--- a/dexmaker-mockito-inline-extended/CMakeLists.txt
+++ b/dexmaker-mockito-inline-extended/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.4.1)
+
+set(slicer_sources
+    ../dexmaker-mockito-inline/external/slicer/bytecode_encoder.cc
+    ../dexmaker-mockito-inline/external/slicer/code_ir.cc
+    ../dexmaker-mockito-inline/external/slicer/common.cc
+    ../dexmaker-mockito-inline/external/slicer/control_flow_graph.cc
+    ../dexmaker-mockito-inline/external/slicer/debuginfo_encoder.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_bytecode.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_format.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_ir_builder.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_ir.cc
+    ../dexmaker-mockito-inline/external/slicer/dex_utf8.cc
+    ../dexmaker-mockito-inline/external/slicer/instrumentation.cc
+    ../dexmaker-mockito-inline/external/slicer/reader.cc
+    ../dexmaker-mockito-inline/external/slicer/tryblocks_encoder.cc
+    ../dexmaker-mockito-inline/external/slicer/writer.cc)
+
+add_library(slicer
+            STATIC
+            ${slicer_sources})
+
+include_directories(../dexmaker-mockito-inline/external/jdk ../dexmaker-mockito-inline/external/slicer/export/)
+
+target_link_libraries(slicer z)
+
+add_library(staticjvmtiagent
+            SHARED
+            src/main/jni/staticjvmtiagent/agent.cc)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -frtti -Wall -Werror -Wno-unused-parameter -Wno-shift-count-overflow -Wno-error=non-virtual-dtor -Wno-sign-compare -Wno-switch -Wno-missing-braces")
+
+target_link_libraries(staticjvmtiagent slicer)

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -29,6 +29,12 @@ android {
         versionName VERSION_NAME
     }
 
+    externalNativeBuild {
+        cmake {
+            path 'CMakeLists.txt'
+        }
+    }
+
     compileOptions {
         targetCompatibility 1.8
         sourceCompatibility 1.8

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -1,0 +1,51 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
+    }
+}
+
+apply plugin: "net.ltgt.errorprone"
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 'android-P'
+    buildToolsVersion '27.0.3'
+
+    android {
+        lintOptions {
+            disable 'InvalidPackage'
+            warning 'NewApi'
+        }
+    }
+
+    defaultConfig {
+        minSdkVersion 1
+        targetSdkVersion 27
+        versionName VERSION_NAME
+    }
+
+    compileOptions {
+        targetCompatibility 1.8
+        sourceCompatibility 1.8
+    }
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs += ["-Xep:StringSplitter:OFF"]
+}
+
+repositories {
+    jcenter()
+    google()
+}
+
+dependencies {
+    implementation project(':dexmaker-mockito-inline')
+
+    implementation 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
+}

--- a/dexmaker-mockito-inline-extended/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-inline-extended/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.dx.mockito.inline.extended" />

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/InlineStaticMockMaker.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/InlineStaticMockMaker.java
@@ -52,6 +52,8 @@ public final class InlineStaticMockMaker implements MockMaker {
     public static ThreadLocal<Class> mockingInProgressClass = new ThreadLocal<>();
     public static ThreadLocal<BiConsumer<Class<?>, Method>> onMethodCallDuringStubbing
             = new ThreadLocal<>();
+    public static ThreadLocal<BiConsumer<Class<?>, Method>> onMethodCallDuringVerification
+            = new ThreadLocal<>();
 
     /*
      * One time setup to allow the system to mocking via this mock maker.

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/InlineStaticMockMaker.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/InlineStaticMockMaker.java
@@ -27,10 +27,12 @@ import org.mockito.plugins.InstantiatorProvider2;
 import org.mockito.plugins.MockMaker;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 /**
  * Creates mock markers and adds stubbing hooks to static method
@@ -48,6 +50,8 @@ public final class InlineStaticMockMaker implements MockMaker {
      */
     private static final Throwable INITIALIZATION_ERROR;
     public static ThreadLocal<Class> mockingInProgressClass = new ThreadLocal<>();
+    public static ThreadLocal<BiConsumer<Class<?>, Method>> onMethodCallDuringStubbing
+            = new ThreadLocal<>();
 
     /*
      * One time setup to allow the system to mocking via this mock maker.

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/InlineStaticMockMaker.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/InlineStaticMockMaker.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline;
+
+import android.os.Build;
+
+import org.mockito.Mockito;
+import org.mockito.creation.instance.Instantiator;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.invocation.MockHandler;
+import org.mockito.mock.MockCreationSettings;
+import org.mockito.plugins.InstantiatorProvider2;
+import org.mockito.plugins.MockMaker;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Creates mock markers and adds stubbing hooks to static method
+ *
+ * <p>This is done by transforming the byte code of the classes to add method entry hooks.
+ */
+public final class InlineStaticMockMaker implements MockMaker {
+    /**
+     * {@link StaticJvmtiAgent} set up during one time init
+     */
+    private static final StaticJvmtiAgent AGENT;
+
+    /**
+     * Error  during one time init or {@code null} if init was successful
+     */
+    private static final Throwable INITIALIZATION_ERROR;
+    public static ThreadLocal<Class> mockingInProgressClass = new ThreadLocal<>();
+
+    /*
+     * One time setup to allow the system to mocking via this mock maker.
+     */
+    static {
+        StaticJvmtiAgent agent;
+        Throwable initializationError = null;
+
+        try {
+            try {
+                agent = new StaticJvmtiAgent();
+            } catch (IOException ioe) {
+                throw new IllegalStateException("Mockito could not self-attach a jvmti agent to " +
+                        "the current VM. This feature is required for inline mocking.\nThis error" +
+                        " occured due to an I/O error during the creation of this agent: " + ioe
+                        + "\n\nPotentially, the current VM does not support the jvmti API " +
+                        "correctly", ioe);
+            }
+        } catch (Throwable throwable) {
+            agent = null;
+            initializationError = throwable;
+        }
+
+        AGENT = agent;
+        INITIALIZATION_ERROR = initializationError;
+    }
+
+    /**
+     * All currently active mock markers. We modify the class's byte code. Some objects of the class
+     * are modified, some are not. This list helps the {@link MockMethodAdvice} help figure out if a
+     * object's method calls should be intercepted.
+     */
+    private final HashMap<Object, InvocationHandlerAdapter> markerToHandler = new HashMap<>();
+    private final Map<Class, Object> classToMarker = new HashMap<>();
+
+    /**
+     * Class doing the actual byte code transformation.
+     */
+    private final StaticClassTransformer classTransformer;
+
+    /**
+     * Create a new mock maker.
+     */
+    public InlineStaticMockMaker() {
+        if (INITIALIZATION_ERROR != null) {
+            throw new RuntimeException("Could not initialize inline mock maker.\n" + "\n" +
+                    "Release: Android " + Build.VERSION.RELEASE + " " + Build.VERSION.INCREMENTAL
+                    + "Device: " + Build.BRAND + " " + Build.MODEL, INITIALIZATION_ERROR);
+        }
+
+        classTransformer = new StaticClassTransformer(AGENT, InlineDexmakerMockMaker
+                .DISPATCHER_CLASS, markerToHandler, classToMarker);
+    }
+
+    @Override
+    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+        Class<T> typeToMock = settings.getTypeToMock();
+        if (!typeToMock.equals(mockingInProgressClass.get()) || Modifier.isAbstract(typeToMock
+                .getModifiers())) {
+            return null;
+        }
+
+        Set<Class<?>> interfacesSet = settings.getExtraInterfaces();
+        InvocationHandlerAdapter handlerAdapter = new InvocationHandlerAdapter(handler);
+
+        classTransformer.mockClass(MockFeatures.withMockFeatures(typeToMock, interfacesSet));
+
+        Instantiator instantiator = Mockito.framework().getPlugins().getDefaultPlugin
+                (InstantiatorProvider2.class).getInstantiator(settings);
+
+        T mock;
+        try {
+            mock = instantiator.newInstance(typeToMock);
+        } catch (org.mockito.creation.instance.InstantiationException e) {
+            throw new MockitoException("Unable to create mock instance of type '" + typeToMock
+                    .getSimpleName() + "'", e);
+        }
+
+        if (classToMarker.containsKey(typeToMock)) {
+            throw new MockitoException(typeToMock + " is already mocked");
+        }
+        classToMarker.put(typeToMock, mock);
+
+        markerToHandler.put(mock, handlerAdapter);
+        return mock;
+    }
+
+    @Override
+    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+        InvocationHandlerAdapter adapter = getInvocationHandlerAdapter(mock);
+        if (adapter != null) {
+            if (mockingInProgressClass.get() == mock.getClass()) {
+                markerToHandler.remove(mock);
+                classToMarker.remove(mock.getClass());
+            } else {
+                adapter.setHandler(newHandler);
+            }
+        }
+    }
+
+    @Override
+    public TypeMockability isTypeMockable(final Class<?> type) {
+        if (mockingInProgressClass.get() == type) {
+            return new TypeMockability() {
+                @Override
+                public boolean mockable() {
+                    return !Modifier.isAbstract(type.getModifiers()) && !type.isPrimitive() && type
+                            != String.class;
+                }
+
+                @Override
+                public String nonMockableReason() {
+                    if (Modifier.isAbstract(type.getModifiers())) {
+                        return "abstract type";
+                    }
+
+                    if (type.isPrimitive()) {
+                        return "primitive type";
+                    }
+
+                    if (type == String.class) {
+                        return "string";
+                    }
+
+                    return "not handled type";
+                }
+            };
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public MockHandler getHandler(Object mock) {
+        InvocationHandlerAdapter adapter = getInvocationHandlerAdapter(mock);
+        return adapter != null ? adapter.getHandler() : null;
+    }
+
+    /**
+     * Get the {@link InvocationHandlerAdapter} registered for a marker.
+     *
+     * @param marker marker of the class that might have mocking set up
+     * @return adapter for this class, or {@code null} if not mocked
+     */
+    private InvocationHandlerAdapter getInvocationHandlerAdapter(Object marker) {
+        if (marker == null) {
+            return null;
+        }
+
+        return markerToHandler.get(marker);
+    }
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticClassTransformer.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticClassTransformer.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline;
+
+import org.mockito.exceptions.base.MockitoException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Adds entry hooks (that eventually call into
+ * {@link StaticMockMethodAdvice#handle(Object, Method, Object[])} to all static methods of the
+ * supplied classes.
+ * <p></p>Transforming a class to add entry hooks follow the following simple steps:
+ * <ol>
+ * <li>{@link #mockClass(MockFeatures)}</li>
+ * <li>{@link StaticJvmtiAgent#requestTransformClasses(Class[])}</li>
+ * <li>{@link StaticJvmtiAgent#nativeRetransformClasses(Class[])}</li>
+ * <li>agent.cc::Transform</li>
+ * <li>{@link StaticJvmtiAgent#runTransformers(ClassLoader, String, Class, ProtectionDomain,
+ *      byte[])}</li>
+ * <li>{@link #transform(Class, byte[])}</li>
+ * <li>{@link #nativeRedefine(String, byte[])}</li>
+ * </ol>
+ */
+class StaticClassTransformer {
+    // Some classes are so deeply optimized inside the runtime that they cannot be transformed
+    private static final Set<Class<? extends java.io.Serializable>> EXCLUDES = new HashSet<>(
+            Arrays.asList(Class.class,
+                    Boolean.class,
+                    Byte.class,
+                    Short.class,
+                    Character.class,
+                    Integer.class,
+                    Long.class,
+                    Float.class,
+                    Double.class,
+                    String.class));
+    /**
+     * We can only have a single transformation going on at a time, hence synchronize the
+     * transformation process via this lock.
+     *
+     * @see #mockClass(MockFeatures)
+     */
+    private final static Object lock = new Object();
+
+    /**
+     * Jvmti agent responsible for triggering transformations
+     */
+    private final StaticJvmtiAgent agent;
+
+    /**
+     * Types that have already be transformed
+     */
+    private final Set<Class<?>> mockedTypes;
+
+    /**
+     * A unique identifier that is baked into the transformed classes. The entry hooks will then
+     * pass this identifier to
+     * {@code com.android.dx.mockito.inline.MockMethodDispatcher#get(String, Object)} to
+     * find the advice responsible for handling the method call interceptions.
+     */
+    private final String identifier;
+
+    /**
+     * Create a new transformer.
+     */
+    StaticClassTransformer(StaticJvmtiAgent agent, Class dispatcherClass,
+                           Map<Object, InvocationHandlerAdapter> markerToHandler, Map<Class, Object>
+                                   classToMarker) {
+        this.agent = agent;
+        mockedTypes = Collections.synchronizedSet(new HashSet<Class<?>>());
+        identifier = String.valueOf(System.identityHashCode(this));
+        StaticMockMethodAdvice advice = new StaticMockMethodAdvice(markerToHandler, classToMarker);
+
+        try {
+            dispatcherClass.getMethod("set", String.class, Object.class).invoke(null, identifier,
+                    advice);
+        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+
+        agent.addTransformer(this);
+    }
+
+    /**
+     * Trigger the process to add entry hooks to a class (and all its parents).
+     *
+     * @param features specification what to mock
+     */
+    <T> void mockClass(MockFeatures<T> features) {
+        boolean subclassingRequired = !features.interfaces.isEmpty()
+                || Modifier.isAbstract(features.mockedType.getModifiers());
+
+        if (subclassingRequired
+                && !features.mockedType.isArray()
+                && !features.mockedType.isPrimitive()
+                && Modifier.isFinal(features.mockedType.getModifiers())) {
+            throw new MockitoException("Unsupported settings with this type '"
+                    + features.mockedType.getName() + "'");
+        }
+
+        synchronized (lock) {
+            Set<Class<?>> types = new HashSet<>();
+            Class<?> type = features.mockedType;
+
+            do {
+                boolean wasAdded = mockedTypes.add(type);
+
+                if (wasAdded) {
+                    if (!EXCLUDES.contains(type)) {
+                        types.add(type);
+                    }
+
+                    type = type.getSuperclass();
+                } else {
+                    break;
+                }
+            } while (type != null && !type.isInterface());
+
+            if (!types.isEmpty()) {
+                try {
+                    agent.requestTransformClasses(types.toArray(new Class<?>[types.size()]));
+                } catch (UnmodifiableClassException exception) {
+                    for (Class<?> failed : types) {
+                        mockedTypes.remove(failed);
+                    }
+
+                    throw new MockitoException("Could not modify all classes " + types, exception);
+                }
+            }
+        }
+    }
+
+    /**
+     * Add entry hooks to all methods of a class.
+     * <p>Called by the agent after triggering the transformation via
+     * {@link #mockClass(MockFeatures)}.
+     *
+     * @param classBeingRedefined class the hooks should be added to
+     * @param classfileBuffer     original byte code of the class
+     * @return transformed class
+     */
+    byte[] transform(Class<?> classBeingRedefined, byte[] classfileBuffer) throws
+            IllegalClassFormatException {
+        if (classBeingRedefined == null
+                || !mockedTypes.contains(classBeingRedefined)) {
+            return null;
+        } else {
+            try {
+                return nativeRedefine(identifier, classfileBuffer);
+            } catch (Throwable throwable) {
+                throw new IllegalClassFormatException();
+            }
+        }
+    }
+
+    /**
+     * Check if the class should be transformed.
+     *
+     * @param classBeingRedefined The class that might need to transformed
+     * @return {@code true} iff the class needs to be transformed
+     */
+    boolean shouldTransform(Class<?> classBeingRedefined) {
+        return classBeingRedefined != null && mockedTypes.contains(classBeingRedefined);
+    }
+
+    private native byte[] nativeRedefine(String identifier, byte[] original);
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticJvmtiAgent.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticJvmtiAgent.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline;
+
+import android.os.Build;
+import android.os.Debug;
+
+import java.io.IOException;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+
+import dalvik.system.BaseDexClassLoader;
+
+/**
+ * Interface to the native jvmti agent in agent.cc
+ */
+class StaticJvmtiAgent {
+    private static final String AGENT_LIB_NAME = "libstaticjvmtiagent.so";
+
+    private static final Object lock = new Object();
+
+    /**
+     * Registered byte code transformers
+     */
+    private final ArrayList<StaticClassTransformer> transformers = new ArrayList<>();
+
+    /**
+     * Enable jvmti and load agent.
+     * <p><b>If there are more than agent transforming classes the other agent might remove
+     * transformations added by this agent.</b>
+     *
+     * @throws IOException If jvmti could not be enabled or agent could not be loaded
+     */
+    StaticJvmtiAgent() throws IOException {
+        // TODO (moltmann@google.com): Replace with proper check for >= P
+        if (!Build.VERSION.CODENAME.equals("P")) {
+            throw new IOException("Requires Android P. Build is " + Build.VERSION.CODENAME);
+        }
+
+        ClassLoader cl = StaticJvmtiAgent.class.getClassLoader();
+        if (!(cl instanceof BaseDexClassLoader)) {
+            throw new IOException("Could not load jvmti plugin as StaticJvmtiAgent class was not loaded "
+                    + "by a BaseDexClassLoader");
+        }
+
+        Debug.attachJvmtiAgent(AGENT_LIB_NAME, null, cl);
+
+        nativeRegisterTransformerHook();
+    }
+
+    private native void nativeRegisterTransformerHook();
+
+    private native void nativeUnregisterTransformerHook();
+
+    @Override
+    protected void finalize() throws Throwable {
+        nativeUnregisterTransformerHook();
+    }
+
+    /**
+     * Ask the agent to trigger transformation of some classes. This will extract the byte code of
+     * the classes and the call back the {@link #addTransformer(StaticClassTransformer)
+     * transformers} for each individual class.
+     *
+     * @param classes The classes to transform
+     * @throws UnmodifiableClassException If one of the classes can not be transformed
+     */
+    void requestTransformClasses(Class<?>[] classes) throws UnmodifiableClassException {
+        synchronized (lock) {
+            try {
+                nativeRetransformClasses(classes);
+            } catch (RuntimeException e) {
+                throw new UnmodifiableClassException(e);
+            }
+        }
+    }
+
+    // called by JNI
+    @SuppressWarnings("unused")
+    public boolean shouldTransform(Class<?> classBeingRedefined) {
+        for (StaticClassTransformer transformer : transformers) {
+            if (transformer.shouldTransform(classBeingRedefined)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Register a transformer. These are called for each class when a transformation was triggered
+     * via {@link #requestTransformClasses(Class[])}.
+     *
+     * @param transformer the transformer to add.
+     */
+    void addTransformer(StaticClassTransformer transformer) {
+        transformers.add(transformer);
+    }
+
+    // called by JNI
+    @SuppressWarnings("unused")
+    public byte[] runTransformers(ClassLoader loader, String className,
+                                  Class<?> classBeingRedefined, ProtectionDomain protectionDomain,
+                                  byte[] classfileBuffer) throws IllegalClassFormatException {
+        byte[] transformedByteCode = classfileBuffer;
+        for (StaticClassTransformer transformer : transformers) {
+            transformedByteCode = transformer.transform(classBeingRedefined, transformedByteCode);
+        }
+
+        return transformedByteCode;
+    }
+
+    private native void nativeRetransformClasses(Class<?>[] classes);
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticJvmtiAgent.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticJvmtiAgent.java
@@ -17,9 +17,9 @@
 package com.android.dx.mockito.inline;
 
 import android.os.Build;
-import android.os.Debug;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 
@@ -51,13 +51,35 @@ class StaticJvmtiAgent {
             throw new IOException("Requires Android P. Build is " + Build.VERSION.CODENAME);
         }
 
+        Throwable loadJvmtiException = null;
+
         ClassLoader cl = StaticJvmtiAgent.class.getClassLoader();
         if (!(cl instanceof BaseDexClassLoader)) {
             throw new IOException("Could not load jvmti plugin as StaticJvmtiAgent class was not loaded "
                     + "by a BaseDexClassLoader");
         }
 
-        Debug.attachJvmtiAgent(AGENT_LIB_NAME, null, cl);
+        try {
+            /*
+             * TODO (moltmann@google.com): Replace with regular method call once the API becomes
+             *                             public
+             */
+            Class.forName("android.os.Debug").getMethod("attachJvmtiAgent", String.class,
+                    String.class, ClassLoader.class).invoke(null, AGENT_LIB_NAME, null, cl);
+        } catch (InvocationTargetException e) {
+            loadJvmtiException = e.getCause();
+        } catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException e) {
+            loadJvmtiException = e;
+        }
+
+        if (loadJvmtiException != null) {
+            if (loadJvmtiException instanceof IOException) {
+                throw (IOException) loadJvmtiException;
+            } else {
+                throw new IOException("Could not load jvmti plugin",
+                        loadJvmtiException);
+            }
+        }
 
         nativeRegisterTransformerHook();
     }

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2018 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package com.android.dx.mockito.inline;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Backend for the method entry hooks. Checks if the hooks should cause an interception or should
+ * be ignored.
+ */
+class StaticMockMethodAdvice {
+    /**
+     * Pattern to decompose a instrumentedMethodWithTypeAndSignature
+     */
+    private final static Pattern methodPattern = Pattern.compile("(.*)#(.*)\\((.*)\\)");
+    private final Map<Object, InvocationHandlerAdapter> markersToHandler;
+    private final Map<Class, Object> classToMarker;
+    @SuppressWarnings("ThreadLocalUsage")
+    private final SelfCallInfo selfCallInfo = new SelfCallInfo();
+
+    StaticMockMethodAdvice(Map<Object, InvocationHandlerAdapter> markerToHandler, Map<Class, Object>
+            classToMarker) {
+        this.markersToHandler = markerToHandler;
+        this.classToMarker = classToMarker;
+    }
+
+    /**
+     * Try to invoke the method {@code origin}.
+     *
+     * @param origin    method to invoke
+     * @param arguments arguments to the method
+     * @return result of the method
+     * @throws Throwable Exception if thrown by the method
+     */
+    private static Object tryInvoke(Method origin, Object[] arguments)
+            throws Throwable {
+        try {
+            return origin.invoke(null, arguments);
+        } catch (InvocationTargetException exception) {
+            throw exception.getCause();
+        }
+    }
+
+    private static Class<?> classForTypeName(String name) throws ClassNotFoundException {
+        if (name.endsWith("[]")) {
+            return Class.forName("[L" + name.substring(0, name.length() - 2) + ";");
+        } else {
+            return Class.forName(name);
+        }
+    }
+
+    private static Class nameToType(String name) throws ClassNotFoundException {
+        switch (name) {
+            case "byte":
+                return Byte.TYPE;
+            case "short":
+                return Short.TYPE;
+            case "int":
+                return Integer.TYPE;
+            case "long":
+                return Long.TYPE;
+            case "char":
+                return Character.TYPE;
+            case "float":
+                return Float.TYPE;
+            case "double":
+                return Double.TYPE;
+            case "boolean":
+                return Boolean.TYPE;
+            case "byte[]":
+                return byte[].class;
+            case "short[]":
+                return short[].class;
+            case "int[]":
+                return int[].class;
+            case "long[]":
+                return long[].class;
+            case "char[]":
+                return char[].class;
+            case "float[]":
+                return float[].class;
+            case "double[]":
+                return double[].class;
+            case "boolean[]":
+                return boolean[].class;
+            default:
+                return classForTypeName(name);
+        }
+    }
+
+    /**
+     * Would a call to SubClass.method handled by SuperClass.method ?
+     * <p>This is the case when subclass or any intermediate parent does not override method.
+     *
+     * @param subclass         Class that might have been called
+     * @param superClass       Class defining the method
+     * @param methodName       Name of method
+     * @param methodParameters Parameter of method
+     * @return {code true} iff the method would have be handled by superClass
+     */
+    private static boolean isMethodDefinedBySuperClass(Class<?> subclass, Class<?> superClass,
+                                                       String methodName,
+                                                       Class<?>[] methodParameters) {
+        do {
+            if (subclass == superClass) {
+                // The method is not overridden in the subclass or any class in between subClass
+                // and superClass.
+                return true;
+            }
+
+            try {
+                subclass.getDeclaredMethod(methodName, methodParameters);
+
+                // method is overridden is sub-class. hence the call could not have handled by
+                // the super-class.
+                return false;
+            } catch (NoSuchMethodException e) {
+                subclass = subclass.getSuperclass();
+            }
+        } while (subclass != null);
+
+        // Subclass is not a sub class of superClass
+        return false;
+    }
+
+    private static List<Class<?>> getAllSubclasses(Class<?> superClass, Collection<Class>
+            possibleSubClasses) {
+        ArrayList<Class<?>> subclasses = new ArrayList<>();
+        for (Class<?> possibleSubClass : possibleSubClasses) {
+            if (superClass.isAssignableFrom(possibleSubClass)) {
+                subclasses.add(possibleSubClass);
+            }
+        }
+
+        return subclasses;
+    }
+
+    private synchronized static native String nativeGetCalledClassName();
+
+    private Class<?> getClassMethodWasCalledOn(MethodDesc methodDesc) throws ClassNotFoundException,
+            NoSuchMethodException {
+        Class<?> classDeclaringMethod = classForTypeName(methodDesc.className);
+
+        /* If a sub-class does not override a static method, the super-classes method is called
+         * directly. Hence 'classDeclaringMethod' will be the super class. As the mocking of
+         * this and the class actually called might be different we need to find the class that
+         * was actually called.
+         */
+        if (Modifier.isFinal(classDeclaringMethod.getModifiers())
+                || Modifier.isFinal(classDeclaringMethod.getDeclaredMethod(methodDesc.methodName,
+                methodDesc.methodParamTypes).getModifiers())) {
+            return classDeclaringMethod;
+        } else {
+            boolean mightBeMocked = false;
+            // if neither the defining class nor any subclass of it is mocked, no point of
+            // trying to figure out the called class as isMocked will soon be checked.
+            for (Class<?> subClass : getAllSubclasses(classDeclaringMethod, classToMarker.keySet())) {
+                if (isMethodDefinedBySuperClass(subClass, classDeclaringMethod,
+                        methodDesc.methodName, methodDesc.methodParamTypes)) {
+                    mightBeMocked = true;
+                    break;
+                }
+            }
+
+            if (!mightBeMocked) {
+                return null;
+            }
+
+            String calledClassName = nativeGetCalledClassName();
+            return Class.forName(calledClassName);
+        }
+    }
+
+    /**
+     * Get the method specified by {@code methodWithTypeAndSignature}.
+     *
+     * @param ignored
+     * @param methodWithTypeAndSignature the description of the method
+     * @return method {@code methodWithTypeAndSignature} refer to
+     */
+    @SuppressWarnings("unused")
+    public Method getOrigin(Object ignored, String methodWithTypeAndSignature) throws Throwable {
+        MethodDesc methodDesc = new MethodDesc(methodWithTypeAndSignature);
+
+        Class clazz = getClassMethodWasCalledOn(methodDesc);
+        if (clazz == null) {
+            return null;
+        }
+
+        Object marker = classToMarker.get(clazz);
+        if (!isMocked(marker)) {
+            return null;
+        }
+
+        return Class.forName(methodDesc.className).getDeclaredMethod(methodDesc.methodName,
+                methodDesc.methodParamTypes);
+    }
+
+    /**
+     * Handle a method entry hook.
+     *
+     * @param origin    method that contains the hook
+     * @param arguments arguments to the method
+     * @return A callable that can be called to get the mocked result or null if the method is not
+     * mocked.
+     */
+    @SuppressWarnings("unused")
+    public Callable<?> handle(Object methodDescStr, Method origin, Object[] arguments) throws
+            Throwable {
+        MethodDesc methodDesc = new MethodDesc((String) methodDescStr);
+        Class clazz = getClassMethodWasCalledOn(methodDesc);
+
+        Object marker = classToMarker.get(clazz);
+        InvocationHandlerAdapter interceptor = markersToHandler.get(marker);
+        if (interceptor == null) {
+            return null;
+        }
+
+        return new ReturnValueWrapper(interceptor.interceptEntryHook(marker, origin, arguments,
+                new SuperMethodCall(selfCallInfo, origin, marker, arguments)));
+    }
+
+    /**
+     * Checks if an {@code marker} is a mock marker.
+     *
+     * @return {@code true} iff the marker is a mock marker
+     */
+    public boolean isMarker(Object marker) {
+        return markersToHandler.containsKey(marker);
+    }
+
+    /**
+     * Check if this method call should be mocked. Usually the same as {@link #isMarker(Object)} but
+     * takes into account the state of {@link #selfCallInfo} that allows to temporary disable
+     * mocking for a single method call.
+     */
+    public boolean isMocked(Object marker) {
+        return selfCallInfo.shouldMockMethod(marker) && isMarker(marker);
+    }
+
+    private static class MethodDesc {
+        final String className;
+        final String methodName;
+        final Class<?>[] methodParamTypes;
+
+        private MethodDesc(String methodWithTypeAndSignature) throws ClassNotFoundException {
+            Matcher methodComponents = methodPattern.matcher(methodWithTypeAndSignature);
+            boolean wasFound = methodComponents.find();
+            if (!wasFound) {
+                throw new IllegalArgumentException();
+            }
+
+            className = methodComponents.group(1);
+            methodName = methodComponents.group(2);
+            String methodParamTypeNames[] = methodComponents.group(3).split(",");
+
+            ArrayList<Class<?>> methodParamTypesList = new ArrayList<>(methodParamTypeNames.length);
+            for (String methodParamName : methodParamTypeNames) {
+                if (!methodParamName.equals("")) {
+                    methodParamTypesList.add(nameToType(methodParamName));
+                }
+            }
+            methodParamTypes = methodParamTypesList.toArray(new Class<?>[]{});
+        }
+
+        @Override
+        public String toString() {
+            return className + "#" + methodName;
+        }
+    }
+
+    /**
+     * Used to call the real (non mocked) method.
+     */
+    private static class SuperMethodCall implements InvocationHandlerAdapter.SuperMethod {
+        private final SelfCallInfo selfCallInfo;
+        private final Method origin;
+        private final Object marker;
+        private final Object[] arguments;
+
+        private SuperMethodCall(SelfCallInfo selfCallInfo, Method origin, Object marker,
+                                Object[] arguments) {
+            this.selfCallInfo = selfCallInfo;
+            this.origin = origin;
+            this.marker = marker;
+            this.arguments = arguments;
+        }
+
+        /**
+         * Call the read (non mocked) method.
+         *
+         * @return Result of read method
+         * @throws Throwable thrown by the read method
+         */
+        @Override
+        public Object invoke() throws Throwable {
+            if (!Modifier.isPublic(origin.getDeclaringClass().getModifiers()
+                    & origin.getModifiers())) {
+                origin.setAccessible(true);
+            }
+
+            // By setting instance in the the selfCallInfo, once single method call on this instance
+            // and thread will call the read method as isMocked will return false.
+            selfCallInfo.set(marker);
+            return tryInvoke(origin, arguments);
+        }
+
+    }
+
+    /**
+     * Stores a return value of {@link #handle(Object, Method, Object[])} and returns in on
+     * {@link #call()}.
+     */
+    private static class ReturnValueWrapper implements Callable<Object> {
+        private final Object returned;
+
+        private ReturnValueWrapper(Object returned) {
+            this.returned = returned;
+        }
+
+        @Override
+        public Object call() {
+            return returned;
+        }
+    }
+
+    /**
+     * Used to call the original method. If a instance is {@link #set(Object)}
+     * {@link #shouldMockMethod(Object)} returns false for this instance once.
+     * <p>This is {@link ThreadLocal}, so a thread can {@link #set(Object)} and instance and then
+     * call {@link #shouldMockMethod(Object)} without interference.
+     *
+     * @see SuperMethodCall#invoke()
+     * @see #isMocked(Object)
+     */
+    private static class SelfCallInfo extends ThreadLocal<Object> {
+        boolean shouldMockMethod(Object value) {
+            Object current = get();
+
+            if (current == value) {
+                set(null);
+                return false;
+            } else {
+                return true;
+            }
+        }
+    }
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
@@ -13,8 +13,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.android.dx.mockito.inline.InlineStaticMockMaker.onMethodCallDuringStubbing;
 
 /**
  * Backend for the method entry hooks. Checks if the hooks should cause an interception or should
@@ -226,6 +229,12 @@ class StaticMockMethodAdvice {
         InvocationHandlerAdapter interceptor = markersToHandler.get(marker);
         if (interceptor == null) {
             return null;
+        }
+
+        // extended.StaticCapableStubber#whenInt
+        BiConsumer<Class<?>, Method> onStub = onMethodCallDuringStubbing.get();
+        if (onStub != null) {
+            onStub.accept(clazz, origin);
         }
 
         return new ReturnValueWrapper(interceptor.interceptEntryHook(marker, origin, arguments,

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
@@ -18,6 +18,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.android.dx.mockito.inline.InlineStaticMockMaker.onMethodCallDuringStubbing;
+import static com.android.dx.mockito.inline.InlineStaticMockMaker.onMethodCallDuringVerification;
 
 /**
  * Backend for the method entry hooks. Checks if the hooks should cause an interception or should
@@ -235,6 +236,12 @@ class StaticMockMethodAdvice {
         BiConsumer<Class<?>, Method> onStub = onMethodCallDuringStubbing.get();
         if (onStub != null) {
             onStub.accept(clazz, origin);
+        }
+
+        // extended.ExtendedMockito#verifyInt
+        BiConsumer<Class<?>, Method> onVerify = onMethodCallDuringVerification.get();
+        if (onVerify != null) {
+            onVerify.accept(clazz, origin);
         }
 
         return new ReturnValueWrapper(interceptor.interceptEntryHook(marker, origin, arguments,

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/ExtendedMockito.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/ExtendedMockito.java
@@ -24,6 +24,26 @@ import java.util.ArrayList;
 
 /**
  * Mockito extended with the ability to stub static methods.
+ * <p>E.g.
+ * <pre>
+ *     private class C {
+ *         static int staticMethod(String arg) {
+ *             return 23;
+ *         }
+ *     }
+ *
+ *    {@literal @}Test
+ *     public void test() {
+ *         // static mocking
+ *         MockitoSession session = mockitoSession().staticSpy(C.class).startMocking();
+ *         try {
+ *             doReturn(42).when(() -> {return C.staticMethod(eq("Arg"));});
+ *             assertEquals(42, C.staticMethod("Arg"));
+ *         } finally {
+ *             session.finishMocking();
+ *         }
+ *     }
+ * </pre>
  * <p>It is possible to use this class for instance mocking too. Hence you can use it as a full
  * replacement for {@link Mockito}.
  * <p>This is a prototype that is intended to eventually be upstreamed into mockito proper. Some
@@ -35,6 +55,80 @@ public class ExtendedMockito extends Mockito {
      * Currently active {@link #mockitoSession() sessions}
      */
     private static ArrayList<StaticMockitoSession> sessions = new ArrayList<>();
+
+    /**
+     * Same as {@link Mockito#doAnswer(Answer)} but adds the ability to stub static method calls via
+     * {@link StaticCapableStubber#when(MockedMethod)} and
+     * {@link StaticCapableStubber#when(MockedVoidMethod)}.
+     */
+    public static StaticCapableStubber doAnswer(Answer answer) {
+        return new StaticCapableStubber(Mockito.doAnswer(answer));
+    }
+
+    /**
+     * Same as {@link Mockito#doCallRealMethod()} but adds the ability to stub static method calls
+     * via {@link StaticCapableStubber#when(MockedMethod)} and
+     * {@link StaticCapableStubber#when(MockedVoidMethod)}.
+     */
+    public static StaticCapableStubber doCallRealMethod() {
+        return new StaticCapableStubber(Mockito.doCallRealMethod());
+    }
+
+    /**
+     * Same as {@link Mockito#doNothing()} but adds the ability to stub static method calls via
+     * {@link StaticCapableStubber#when(MockedMethod)} and
+     * {@link StaticCapableStubber#when(MockedVoidMethod)}.
+     */
+    public static StaticCapableStubber doNothing() {
+        return new StaticCapableStubber(Mockito.doNothing());
+    }
+
+    /**
+     * Same as {@link Mockito#doReturn(Object)} but adds the ability to stub static method calls
+     * via {@link StaticCapableStubber#when(MockedMethod)} and
+     * {@link StaticCapableStubber#when(MockedVoidMethod)}.
+     */
+    public static StaticCapableStubber doReturn(Object toBeReturned) {
+        return new StaticCapableStubber(Mockito.doReturn(toBeReturned));
+    }
+
+    /**
+     * Same as {@link Mockito#doReturn(Object, Object...)} but adds the ability to stub static
+     * method calls via {@link StaticCapableStubber#when(MockedMethod)} and
+     * {@link StaticCapableStubber#when(MockedVoidMethod)}.
+     */
+    public static StaticCapableStubber doReturn(Object toBeReturned, Object... toBeReturnedNext) {
+        return new StaticCapableStubber(Mockito.doReturn(toBeReturned, toBeReturnedNext));
+    }
+
+    /**
+     * Same as {@link Mockito#doThrow(Class)} but adds the ability to stub static method calls via
+     * {@link StaticCapableStubber#when(MockedMethod)} and
+     * {@link StaticCapableStubber#when(MockedVoidMethod)}.
+     */
+    public static StaticCapableStubber doThrow(Class<? extends Throwable> toBeThrown) {
+        return new StaticCapableStubber(Mockito.doThrow(toBeThrown));
+    }
+
+    /**
+     * Same as {@link Mockito#doThrow(Class, Class...)} but adds the ability to stub static method
+     * calls via {@link StaticCapableStubber#when(MockedMethod)} and
+     * {@link StaticCapableStubber#when(MockedVoidMethod)}.
+     */
+    @SafeVarargs
+    public static StaticCapableStubber doThrow(Class<? extends Throwable> toBeThrown,
+                                               Class<? extends Throwable>... toBeThrownNext) {
+        return new StaticCapableStubber(Mockito.doThrow(toBeThrown, toBeThrownNext));
+    }
+
+    /**
+     * Same as {@link Mockito#doThrow(Throwable...)} but adds the ability to stub static method
+     * calls via {@link StaticCapableStubber#when(MockedMethod)} and
+     * {@link StaticCapableStubber#when(MockedVoidMethod)}.
+     */
+    public static StaticCapableStubber doThrow(Throwable... toBeThrown) {
+        return new StaticCapableStubber(Mockito.doThrow(toBeThrown));
+    }
 
     /**
      * Many methods of mockito take mock objects. To be able to call the same methods for static

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/ExtendedMockito.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/ExtendedMockito.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended;
+
+import org.mockito.Mockito;
+
+/**
+ * Mockito extended with ... nothing yet
+ * <p>It is possible to use this class for instance mocking too. Hence you can use it as a full
+ * replacement for {@link Mockito}.
+ * <p>This is a prototype that is intended to eventually be upstreamed into mockito proper. Some
+ * APIs might change. All such APIs are annotated with {@link UnstableApi}.
+ */
+@UnstableApi
+public class ExtendedMockito extends Mockito {
+
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/ExtendedMockito.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/ExtendedMockito.java
@@ -16,10 +16,14 @@
 
 package com.android.dx.mockito.inline.extended;
 
+import org.mockito.MockSettings;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
 
 /**
- * Mockito extended with ... nothing yet
+ * Mockito extended with the ability to stub static methods.
  * <p>It is possible to use this class for instance mocking too. Hence you can use it as a full
  * replacement for {@link Mockito}.
  * <p>This is a prototype that is intended to eventually be upstreamed into mockito proper. Some
@@ -27,5 +31,89 @@ import org.mockito.Mockito;
  */
 @UnstableApi
 public class ExtendedMockito extends Mockito {
+    /**
+     * Currently active {@link #mockitoSession() sessions}
+     */
+    private static ArrayList<StaticMockitoSession> sessions = new ArrayList<>();
 
+    /**
+     * Many methods of mockito take mock objects. To be able to call the same methods for static
+     * mocking, this method gets a marker object that can be used instead.
+     *
+     * @param clazz The class object the marker should be crated for
+     * @return A marker object. This should not be used directly. It can only be passed into other
+     * ExtendedMockito methods.
+     * @see #inOrder(Object...)
+     * @see #clearInvocations(Object...)
+     * @see #ignoreStubs(Object...)
+     * @see #mockingDetails(Object)
+     * @see #reset(Object[])
+     * @see #verifyNoMoreInteractions(Object...)
+     * @see #verifyZeroInteractions(Object...)
+     */
+    @UnstableApi
+    @SuppressWarnings("unchecked")
+    public static <T> T staticMockMarker(Class<T> clazz) {
+        for (StaticMockitoSession session : sessions) {
+            T marker = session.staticMockMarker(clazz);
+
+            if (marker != null) {
+                return marker;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Same as {@link #staticMockMarker(Class)} but for multiple classes at once.
+     */
+    @UnstableApi
+    public static Object[] staticMockMarker(Class<?>... clazz) {
+        Object[] markers = new Object[clazz.length];
+
+        for (int i = 0; i < clazz.length; i++) {
+            for (StaticMockitoSession session : sessions) {
+                markers[i] = session.staticMockMarker(clazz[i]);
+
+                if (markers[i] != null) {
+                    break;
+                }
+            }
+
+            if (markers[i] == null) {
+                return null;
+            }
+        }
+
+        return markers;
+    }
+
+    /**
+     * Same as {@link Mockito#mockitoSession()} but adds the ability to mock static methods
+     * calls via {@link StaticMockitoSessionBuilder#mockStatic(Class)},
+     * {@link StaticMockitoSessionBuilder#mockStatic(Class, Answer)}, and {@link
+     * StaticMockitoSessionBuilder#mockStatic(Class, MockSettings)};
+     * <p>All mocking spying will be removed once the session is finished.
+     */
+    public static StaticMockitoSessionBuilder mockitoSession() {
+        return new StaticMockitoSessionBuilder(Mockito.mockitoSession());
+    }
+
+    /**
+     * Register a new session.
+     *
+     * @param session Session to register
+     */
+    static void addSession(StaticMockitoSession session) {
+        sessions.add(session);
+    }
+
+    /**
+     * Remove a finished session.
+     *
+     * @param session Session to remove
+     */
+    static void removeSession(StaticMockitoSession session) {
+        sessions.remove(session);
+    }
 }

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/MockedMethod.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/MockedMethod.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended;
+
+/**
+ * A call to a method that should be stubbed / verified.
+ *
+ * @param <T> return type of the method
+ */
+@UnstableApi
+public interface MockedMethod<T> {
+    T get() throws Throwable;
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/MockedVoidMethod.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/MockedVoidMethod.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended;
+
+/**
+ * A call to a void method that should be stubbed / verified.
+ */
+@UnstableApi
+public interface MockedVoidMethod {
+    void run() throws Throwable;
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticCapableStubber.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticCapableStubber.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended;
+
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.Stubber;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+
+import static com.android.dx.mockito.inline.InlineStaticMockMaker.onMethodCallDuringStubbing;
+
+/**
+ * Same as {@link Stubber} but supports settings up stubbing of static methods via
+ * {@link #when(MockedMethod)} and {@link #when(MockedVoidMethod)}.
+ */
+@UnstableApi
+public class StaticCapableStubber implements Stubber {
+    private Stubber instanceStubber;
+
+    StaticCapableStubber(Stubber instanceStubber) {
+        this.instanceStubber = instanceStubber;
+    }
+
+    @Override
+    public <T> T when(T mock) {
+        return instanceStubber.when(mock);
+    }
+
+    /**
+     * Common implementation of all {@code doReturn.when} calls.
+     *
+     * @param method The static method to be stubbed
+     */
+    private void whenInt(MockedVoidMethod method) {
+        if (onMethodCallDuringStubbing.get() != null) {
+            throw new IllegalStateException("Stubbing is already in progress on this thread.");
+        }
+
+        ArrayList<Method> stubbingsSetUp = new ArrayList<>();
+
+        /* Set up interception of method. 'method' does not specify what class the stubbing is
+         * set up on. Hence wait until the call is made and intercept it just before the code
+         * is executed. At this time, start the stubbing operation.
+         */
+        onMethodCallDuringStubbing.set((clazz, stubbedMethod) -> {
+            when(ExtendedMockito.staticMockMarker(clazz));
+            stubbingsSetUp.add(stubbedMethod);
+        });
+        try {
+            try {
+                // Call the method. This will be intercepted by onMethodCallDuringStubbing
+                method.run();
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+
+            if (stubbingsSetUp.isEmpty()) {
+                // Make sure something was intercepted
+                throw new IllegalArgumentException("Nothing was stubbed. Does the lambda call a"
+                        + " static method on a 'static' mock/spy?");
+            } else if (stubbingsSetUp.size() > 1) {
+                // A lambda might call several methods. In this case it is not clear what should
+                // be stubbed. Hence throw an error.
+                throw new IllegalArgumentException("Multiple intercepted calls on method "
+                        + stubbingsSetUp);
+            }
+        } finally {
+            onMethodCallDuringStubbing.remove();
+        }
+    }
+
+    /**
+     * Set up stubbing for a static void method.
+     * <pre>
+     *     private class C {
+     *         void instanceMethod(String arg) {}
+     *         static void staticMethod(String arg) {}
+     *     }
+     *
+     *    {@literal @}Test
+     *     public void test() {
+     *         // instance mocking
+     *         C mock = mock(C.class);
+     *         doThrow(Exception.class).when(mock).instanceMethod(eq("Hello));
+     *         assertThrows(Exception.class, mock.instanceMethod("Hello"));
+     *
+     *         // static mocking
+     *         MockitoSession session = mockitoSession().staticMock(C.class).startMocking();
+     *         doThrow(Exception.class).when(() -> C.instanceMethod(eq("Hello));
+     *         assertThrows(Exception.class, C.staticMethod("Hello"));
+     *         session.finishMocking();
+     *     }
+     * </pre>
+     *
+     * @param method The method to stub as a lambda. This should only call a single stubbable
+     *               static method.
+     */
+    @UnstableApi
+    public void when(MockedVoidMethod method) {
+        whenInt(method);
+    }
+
+    /**
+     * Set up stubbing for a static method.
+     * <pre>
+     *     private class C {
+     *         int instanceMethod(String arg) {
+     *             return 1;
+     *         }
+     *
+     *         int static staticMethod(String arg) {
+     *             return 1;
+     *         }
+     *     }
+     *
+     *    {@literal @}Test
+     *     public void test() {
+     *         // instance mocking
+     *         C mock = mock(C.class);
+     *         doReturn(2).when(mock).instanceMethod(eq("Hello));
+     *         assertEquals(2, mock.instanceMethod("Hello"));
+     *
+     *         // static mocking
+     *         MockitoSession session = mockitoSession().staticMock(C.class).startMocking();
+     *         doReturn(2).when(() -> C.instanceMethod(eq("Hello));
+     *         assertEquals(2, C.staticMethod("Hello"));
+     *         session.finishMocking();
+     *     }
+     * </pre>
+     *
+     * @param method The method to stub as a lambda. This should only call a single stubbable
+     *               static method.
+     * @param <T>    Return type of the stubbed method
+     */
+    @UnstableApi
+    public <T> void when(MockedMethod<T> method) {
+        whenInt(method::get);
+    }
+
+    @Override
+    public StaticCapableStubber doThrow(Throwable... toBeThrown) {
+        instanceStubber = instanceStubber.doThrow(toBeThrown);
+        return this;
+    }
+
+    @Override
+    public StaticCapableStubber doThrow(Class<? extends Throwable> toBeThrown) {
+        instanceStubber = instanceStubber.doThrow(toBeThrown);
+        return this;
+    }
+
+    @SafeVarargs
+    @Override
+    public final StaticCapableStubber doThrow(Class<? extends Throwable> toBeThrown,
+                                              Class<? extends Throwable>... nextToBeThrown) {
+        instanceStubber = instanceStubber.doThrow(toBeThrown, nextToBeThrown);
+        return this;
+    }
+
+    @Override
+    public StaticCapableStubber doAnswer(Answer answer) {
+        instanceStubber = instanceStubber.doAnswer(answer);
+        return this;
+    }
+
+    @Override
+    public StaticCapableStubber doNothing() {
+        instanceStubber = instanceStubber.doNothing();
+        return this;
+    }
+
+    @Override
+    public StaticCapableStubber doReturn(Object toBeReturned) {
+        instanceStubber = instanceStubber.doReturn(toBeReturned);
+        return this;
+    }
+
+    @Override
+    public StaticCapableStubber doReturn(Object toBeReturned, Object... nextToBeReturned) {
+        instanceStubber = instanceStubber.doReturn(toBeReturned, nextToBeReturned);
+        return this;
+    }
+
+    @Override
+    public StaticCapableStubber doCallRealMethod() {
+        instanceStubber = instanceStubber.doCallRealMethod();
+        return this;
+    }
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticInOrder.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticInOrder.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended;
+
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
+
+/**
+ * Same as {@link InOrder} but adds the ability to verify static method calls via
+ * {@link #verify(MockedMethod)}, {@link #verify(MockedVoidMethod)},
+ * {@link #verify(MockedMethod, VerificationMode)}, and
+ * {@link #verify(MockedVoidMethod, VerificationMode)}.
+ */
+@UnstableApi
+public class StaticInOrder implements InOrder {
+    private final InOrder instanceInOrder;
+
+    StaticInOrder(InOrder inOrder) {
+        instanceInOrder = inOrder;
+    }
+
+    @Override
+    public <T> T verify(T mock) {
+        return instanceInOrder.verify(mock);
+    }
+
+    @Override
+    public <T> T verify(T mock, VerificationMode mode) {
+        return instanceInOrder.verify(mock, mode);
+    }
+
+    /**
+     * To be used for static mocks/spies in place of {@link #verify(Object)} when calling void
+     * methods.
+     * <p>E.g.
+     * <pre>
+     *     private class C {
+     *         void instanceMethod(String arg) {}
+     *         void void staticMethod(String arg) {}
+     *     }
+     *
+     *    {@literal @}Test
+     *     public void test() {
+     *         // instance mocking
+     *         C mock = mock(C.class);
+     *         mock.staticMethod("Hello");
+     *         mock.instanceMethod("World");
+     *         inOrder().verify(mock).mockedVoidInstanceMethod(eq("Hello"));
+     *         inOrder().verify(mock).mockedVoidInstanceMethod(eq("World"));
+     *
+     *         // static mocking
+     *         MockitoSession session = mockitoSession().staticMock(C.class).startMocking();
+     *         C.staticMethod("Hello");
+     *         C.staticMethod("World");
+     *
+     *         StaticInOrder inOrder = inOrder();
+     *         inOrder.verify(() -> C.staticMethod(eq("Hello"));
+     *         inOrder.verify(() -> C.staticMethod(eq("World"));
+     *         session.finishMocking();
+     *     }
+     * </pre>
+     */
+    public void verify(MockedVoidMethod method) {
+        verify(method, Mockito.times(1));
+    }
+
+    /**
+     * To be used for static mocks/spies in place of {@link #verify(Object)}.
+     * <p>E.g.
+     * <pre>
+     *     private class C {
+     *         int instanceMethod(String arg) {
+     *             return 1;
+     *         }
+     *
+     *         int static staticMethod(String arg) {
+     *             return 2;
+     *         }
+     *     }
+     *
+     *    {@literal @}Test
+     *     public void test() {
+     *         // instance mocking
+     *         C mock = mock(C.class);
+     *         mock.instanceMethod("Hello");
+     *         mock.instanceMethod("World");
+     *         inOrder().verify(mock).mockedVoidInstanceMethod(eq("Hello"));
+     *         inOrder().verify(mock).mockedVoidInstanceMethod(eq("World"));
+     *
+     *         // static mocking
+     *         MockitoSession session = mockitoSession().staticMock(C.class).startMocking();
+     *         C.staticMethod("Hello");
+     *         C.staticMethod("World");
+     *
+     *         StaticInOrder inOrder = inOrder();
+     *         inOrder.verify(() -> C.staticMethod(eq("Hello"));
+     *         inOrder.verify(() -> C.staticMethod(eq("World"));
+     *         session.finishMocking();
+     *     }
+     * </pre>
+     */
+    @UnstableApi
+    public void verify(MockedMethod method) {
+        verify(method, Mockito.times(1));
+    }
+
+    /**
+     * To be used for static mocks/spies in place of
+     * {@link InOrder#verify(Object, VerificationMode)} when calling void methods.
+     *
+     * @see #verify(MockedVoidMethod)
+     */
+    @UnstableApi
+    public void verify(MockedVoidMethod method, VerificationMode mode) {
+        ExtendedMockito.verifyInt(method, mode, instanceInOrder);
+    }
+
+    /**
+     * To be used for static mocks/spies in place of
+     * {@link InOrder#verify(Object, VerificationMode)}.
+     *
+     * @see #verify(MockedMethod)
+     */
+    @UnstableApi
+    public void verify(MockedMethod method, VerificationMode mode) {
+        verify((MockedVoidMethod) method::get, mode);
+    }
+
+    @Override
+    public void verifyNoMoreInteractions() {
+        instanceInOrder.verifyNoMoreInteractions();
+    }
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticMocking.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticMocking.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended;
+
+import java.util.function.Supplier;
+
+/**
+ * Data class for a class and the way to create the marker object for the class. As all
+ * invocations are routed to the marker the way we create the marker also determines the other
+ * properties of the mock.
+ */
+class StaticMocking<T> {
+    final Class<T> clazz;
+    final Supplier<T> markerSupplier;
+
+    StaticMocking(Class<T> clazz, Supplier<T> markerSupplier) {
+        this.clazz = clazz;
+        this.markerSupplier = markerSupplier;
+    }
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticMockitoSession.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticMockitoSession.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended;
+
+import org.mockito.Mockito;
+import org.mockito.MockitoSession;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static com.android.dx.mockito.inline.InlineStaticMockMaker.mockingInProgressClass;
+
+/**
+ * Same as {@link MockitoSession} but used when static methods are also stubbed.
+ */
+@UnstableApi
+public class StaticMockitoSession implements MockitoSession {
+    /**
+     * For each class where static mocking is enabled there is one marker object.
+     */
+    private static final HashMap<Class, Object> classToMarker = new HashMap<>();
+
+    private final MockitoSession instanceSession;
+    private final ArrayList<Class<?>> staticMocks = new ArrayList<>(0);
+
+    StaticMockitoSession(MockitoSession instanceSession) {
+        ExtendedMockito.addSession(this);
+        this.instanceSession = instanceSession;
+    }
+
+    @Override
+    public void setStrictness(Strictness strictness) {
+        instanceSession.setStrictness(strictness);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p><b>Extension:</b> This also resets all stubbing of static methods set up in the
+     * {@link ExtendedMockito#mockitoSession() builder} of the session.
+     */
+    @Override
+    public void finishMocking() {
+        finishMocking(null);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p><b>Extension:</b> This also resets all stubbing of static methods set up in the
+     * {@link ExtendedMockito#mockitoSession() builder} of the session.
+     */
+    @Override
+    public void finishMocking(Throwable failure) {
+        try {
+            instanceSession.finishMocking(failure);
+        } finally {
+            for (Class<?> clazz : staticMocks) {
+                mockingInProgressClass.set(clazz);
+                try {
+                    Mockito.reset(ExtendedMockito.staticMockMarker(clazz));
+                } finally {
+                    mockingInProgressClass.remove();
+                }
+                classToMarker.remove(clazz);
+            }
+
+            ExtendedMockito.removeSession(this);
+        }
+    }
+
+    /**
+     * Init mocking for a class.
+     *
+     * @param mocking Description and settings of the mocking
+     * @param <T>     The class to mock
+     */
+    <T> void mockStatic(StaticMocking<T> mocking) {
+        if (ExtendedMockito.staticMockMarker(mocking.clazz) != null) {
+            throw new IllegalArgumentException(mocking.clazz + " is already mocked");
+        }
+
+        mockingInProgressClass.set(mocking.clazz);
+        try {
+            classToMarker.put(mocking.clazz, mocking.markerSupplier.get());
+        } finally {
+            mockingInProgressClass.remove();
+        }
+
+        staticMocks.add(mocking.clazz);
+    }
+
+    /**
+     * Get marker for a mocked/spies class or {@code null}.
+     *
+     * @param clazz The class that is mocked
+     * @return marker for a mocked class or {@code null} if class is not mocked in this session
+     * @see ExtendedMockito#staticMockMarker(Class)
+     */
+    @SuppressWarnings("unchecked")
+    <T> T staticMockMarker(Class<T> clazz) {
+        return (T) classToMarker.get(clazz);
+    }
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticMockitoSessionBuilder.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticMockitoSessionBuilder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended;
+
+import org.mockito.MockSettings;
+import org.mockito.Mockito;
+import org.mockito.exceptions.misusing.UnfinishedMockingSessionException;
+import org.mockito.quality.Strictness;
+import org.mockito.session.MockitoSessionBuilder;
+import org.mockito.session.MockitoSessionLogger;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+
+/**
+ * Same as {@link MockitoSessionBuilder} but adds the ability to stub static methods
+ * calls via {@link #mockStatic(Class)}, {@link #mockStatic(Class, Answer)}, and
+ * {@link #mockStatic(Class, MockSettings)};
+ * <p>All mocks/spies will be reset once the session is finished.
+ */
+@UnstableApi
+public class StaticMockitoSessionBuilder implements MockitoSessionBuilder {
+    private final ArrayList<StaticMocking> staticMockings = new ArrayList<>(0);
+    private MockitoSessionBuilder instanceSessionBuilder;
+
+    StaticMockitoSessionBuilder(MockitoSessionBuilder instanceSessionBuilder) {
+        this.instanceSessionBuilder = instanceSessionBuilder;
+    }
+
+    /**
+     * Sets up mocking for all static methods of a class. All methods will return the default value.
+     * <p>This changes the behavior of <u>all</u> static methods calls for <u>all</u>
+     * invocations. In most cases using {@link #spyStatic(Class)} and stubbing only a few
+     * methods can be used.
+     *
+     * @param clazz The class to set up static mocking for
+     * @return This builder
+     */
+    @UnstableApi
+    public <T> StaticMockitoSessionBuilder mockStatic(Class<T> clazz) {
+        staticMockings.add(new StaticMocking<>(clazz, () -> Mockito.mock(clazz)));
+        return this;
+    }
+
+    /**
+     * Sets up mocking for sall tatic methods of a class. All methods will call the {@code
+     * defaultAnswer}.
+     * <p>This changes the behavior of <u>all</u> static methods calls for <u>all</u>
+     * invocations. In most cases using {@link #spyStatic(Class)} and stubbing only a few
+     * methods can be used.
+     *
+     * @param clazz         The class to set up static mocking for
+     * @param defaultAnswer The answer to return by default
+     * @return This builder
+     */
+    @UnstableApi
+    public <T> StaticMockitoSessionBuilder mockStatic(Class<T> clazz, Answer defaultAnswer) {
+        staticMockings.add(new StaticMocking<>(clazz, () -> Mockito.mock(clazz, defaultAnswer)));
+        return this;
+    }
+
+    /**
+     * Sets up mocking for all static methods of a class with custom {@link MockSettings}.
+     * <p>This changes the behavior of <u>all</u> static methods calls for <u>all</u>
+     * invocations. In most cases using {@link #spyStatic(Class)} and stubbing only a few
+     * methods can be used.
+     *
+     * @param clazz    The class to set up static mocking for
+     * @param settings Settings used to set up the mock.
+     * @return This builder
+     */
+    @UnstableApi
+    public <T> StaticMockitoSessionBuilder mockStatic(Class<T> clazz, MockSettings settings) {
+        staticMockings.add(new StaticMocking<>(clazz, () -> Mockito.mock(clazz, settings)));
+        return this;
+    }
+
+    /**
+     * Sets up spying for static methods of a class.
+     *
+     * @param clazz The class to set up static spying for
+     * @return This builder
+     */
+    @UnstableApi
+    public <T> StaticMockitoSessionBuilder spyStatic(Class<T> clazz) {
+        staticMockings.add(new StaticMocking<>(clazz, () -> Mockito.spy(clazz)));
+        return this;
+    }
+
+    @Override
+    public StaticMockitoSessionBuilder initMocks(Object testClassInstance) {
+        instanceSessionBuilder = instanceSessionBuilder.initMocks(testClassInstance);
+        return this;
+    }
+
+    @Override
+    public StaticMockitoSessionBuilder initMocks(Object... testClassInstances) {
+        instanceSessionBuilder = instanceSessionBuilder.initMocks(testClassInstances);
+        return this;
+    }
+
+    @Override
+    public StaticMockitoSessionBuilder name(String name) {
+        instanceSessionBuilder = instanceSessionBuilder.name(name);
+        return this;
+    }
+
+    @Override
+    public StaticMockitoSessionBuilder strictness(Strictness strictness) {
+        instanceSessionBuilder = instanceSessionBuilder.strictness(strictness);
+        return this;
+    }
+
+    @Override
+    public StaticMockitoSessionBuilder logger(MockitoSessionLogger logger) {
+        instanceSessionBuilder = instanceSessionBuilder.logger(logger);
+        return this;
+    }
+
+    @Override
+    public StaticMockitoSession startMocking() throws UnfinishedMockingSessionException {
+        StaticMockitoSession session
+                = new StaticMockitoSession(instanceSessionBuilder.startMocking());
+        try {
+            for (StaticMocking mocking : staticMockings) {
+                session.mockStatic((StaticMocking<?>) mocking);
+            }
+        } catch (Throwable t) {
+            try {
+                session.finishMocking();
+            } catch (Throwable ignored) {
+                // suppress all failures
+            }
+            throw t;
+        }
+
+        return session;
+    }
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/UnstableApi.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/UnstableApi.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * The API is not a mockito API and there is a chance in might change in future versions. Some
+ * classes inherit from Mockito classes. In this case the class name is not stable, but the
+ * inherited methods are.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Documented
+public @interface UnstableApi {
+}

--- a/dexmaker-mockito-inline-extended/src/main/jni/staticjvmtiagent/agent.cc
+++ b/dexmaker-mockito-inline-extended/src/main/jni/staticjvmtiagent/agent.cc
@@ -1,0 +1,833 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdlib>
+#include <sstream>
+#include <cstring>
+#include <cassert>
+#include <cstdarg>
+#include <algorithm>
+
+#include <jni.h>
+
+#include "jvmti.h"
+
+#include <slicer/dex_ir.h>
+#include <slicer/code_ir.h>
+#include <slicer/dex_ir_builder.h>
+#include <slicer/dex_utf8.h>
+#include <slicer/writer.h>
+#include <slicer/reader.h>
+#include <slicer/instrumentation.h>
+
+using namespace dex;
+using namespace lir;
+
+namespace com_android_dx_mockito_inline {
+    static jvmtiEnv* localJvmtiEnv;
+
+    static jobject sTransformer;
+
+    // Converts a class name to a type descriptor
+    // (ex. "java.lang.String" to "Ljava/lang/String;")
+    static std::string
+    ClassNameToDescriptor(const char* class_name) {
+        std::stringstream ss;
+        ss << "L";
+        for (auto p = class_name; *p != '\0'; ++p) {
+            ss << (*p == '.' ? '/' : *p);
+        }
+        ss << ";";
+        return ss.str();
+    }
+
+    // Takes the full dex file for class 'classBeingRedefined'
+    // - isolates the dex code for the class out of the dex file
+    // - calls sTransformer.runTransformers on the isolated dex code
+    // - send the transformed code back to the runtime
+    static void
+    Transform(jvmtiEnv* jvmti_env,
+              JNIEnv* env,
+              jclass classBeingRedefined,
+              jobject loader,
+              const char* name,
+              jobject protectionDomain,
+              jint classDataLen,
+              const unsigned char* classData,
+              jint* newClassDataLen,
+              unsigned char** newClassData) {
+        if (sTransformer != nullptr) {
+            // Even reading the classData array is expensive as the data is only generated when the
+            // memory is touched. Hence call JvmtiAgent#shouldTransform to check if we need to transform
+            // the class.
+            jclass cls = env->GetObjectClass(sTransformer);
+            jmethodID shouldTransformMethod = env->GetMethodID(cls, "shouldTransform",
+                                                               "(Ljava/lang/Class;)Z");
+
+            jboolean shouldTransform = env->CallBooleanMethod(sTransformer, shouldTransformMethod,
+                                                              classBeingRedefined);
+            if (!shouldTransform) {
+                return;
+            }
+
+            // Isolate byte code of class class. This is needed as Android usually gives us more
+            // than the class we need.
+            Reader reader(classData, classDataLen);
+
+            u4 index = reader.FindClassIndex(ClassNameToDescriptor(name).c_str());
+            reader.CreateClassIr(index);
+            std::shared_ptr<ir::DexFile> ir = reader.GetIr();
+
+            struct Allocator : public Writer::Allocator {
+                virtual void* Allocate(size_t size) {return ::malloc(size);}
+                virtual void Free(void* ptr) {::free(ptr);}
+            };
+
+            Allocator allocator;
+            Writer writer(ir);
+            size_t isolatedClassLen = 0;
+            std::shared_ptr<jbyte> isolatedClass((jbyte*)writer.CreateImage(&allocator,
+                                                                            &isolatedClassLen));
+
+            // Create jbyteArray with isolated byte code of class
+            jbyteArray isolatedClassArr = env->NewByteArray(isolatedClassLen);
+            env->SetByteArrayRegion(isolatedClassArr, 0, isolatedClassLen,
+                                    isolatedClass.get());
+
+            jstring nameStr = env->NewStringUTF(name);
+
+            // Call JvmtiAgent#runTransformers
+            jmethodID runTransformersMethod = env->GetMethodID(cls, "runTransformers",
+                                                               "(Ljava/lang/ClassLoader;"
+                                                               "Ljava/lang/String;"
+                                                               "Ljava/lang/Class;"
+                                                               "Ljava/security/ProtectionDomain;"
+                                                               "[B)[B");
+
+            jbyteArray transformedArr = (jbyteArray) env->CallObjectMethod(sTransformer,
+                                                                           runTransformersMethod,
+                                                                           loader, nameStr,
+                                                                           classBeingRedefined,
+                                                                           protectionDomain,
+                                                                           isolatedClassArr);
+
+            // Set transformed byte code
+            if (!env->ExceptionOccurred() && transformedArr != nullptr) {
+                *newClassDataLen = env->GetArrayLength(transformedArr);
+
+                jbyte* transformed = env->GetByteArrayElements(transformedArr, 0);
+
+                jvmti_env->Allocate(*newClassDataLen, newClassData);
+                std::memcpy(*newClassData, transformed, *newClassDataLen);
+
+                env->ReleaseByteArrayElements(transformedArr, transformed, 0);
+            }
+        }
+    }
+
+    // Add a label before instructionAfter
+    static void
+    addLabel(CodeIr& c,
+             lir::Instruction* instructionAfter,
+             Label* returnTrueLabel) {
+        c.instructions.InsertBefore(instructionAfter, returnTrueLabel);
+    }
+
+    // Add a byte code before instructionAfter
+    static void
+    addInstr(CodeIr& c,
+             lir::Instruction* instructionAfter,
+             Opcode opcode,
+             const std::list<Operand*>& operands) {
+        auto instruction = c.Alloc<Bytecode>();
+
+        instruction->opcode = opcode;
+
+        for (auto it = operands.begin(); it != operands.end(); it++) {
+            instruction->operands.push_back(*it);
+        }
+
+        c.instructions.InsertBefore(instructionAfter, instruction);
+    }
+
+    // Add a method call byte code before instructionAfter
+    static void
+    addCall(ir::Builder& b,
+            CodeIr& c,
+            lir::Instruction* instructionAfter,
+            Opcode opcode,
+            ir::Type* type,
+            const char* methodName,
+            ir::Type* returnType,
+            const std::vector<ir::Type*>& types,
+            const std::list<int>& regs) {
+        auto proto = b.GetProto(returnType, b.GetTypeList(types));
+        auto method = b.GetMethodDecl(b.GetAsciiString(methodName), proto, type);
+
+        VRegList* param_regs = c.Alloc<VRegList>();
+        for (auto it = regs.begin(); it != regs.end(); it++) {
+            param_regs->registers.push_back(*it);
+        }
+
+        addInstr(c, instructionAfter, opcode, {param_regs, c.Alloc<Method>(method,
+                                                                           method->orig_index)});
+    }
+
+    typedef struct {
+        ir::Type* boxedType;
+        ir::Type* scalarType;
+        std::string unboxMethod;
+    } BoxingInfo;
+
+    // Get boxing / unboxing info for a type
+    static BoxingInfo
+    getBoxingInfo(ir::Builder &b,
+                  char typeCode) {
+        BoxingInfo boxingInfo;
+
+        if (typeCode != 'L' && typeCode !=  '[') {
+            std::stringstream tmp;
+            tmp << typeCode;
+            boxingInfo.scalarType = b.GetType(tmp.str().c_str());
+        }
+
+        switch (typeCode) {
+            case 'B':
+                boxingInfo.boxedType = b.GetType("Ljava/lang/Byte;");
+                boxingInfo.unboxMethod = "byteValue";
+                break;
+            case 'S':
+                boxingInfo.boxedType = b.GetType("Ljava/lang/Short;");
+                boxingInfo.unboxMethod = "shortValue";
+                break;
+            case 'I':
+                boxingInfo.boxedType = b.GetType("Ljava/lang/Integer;");
+                boxingInfo.unboxMethod = "intValue";
+                break;
+            case 'C':
+                boxingInfo.boxedType = b.GetType("Ljava/lang/Character;");
+                boxingInfo.unboxMethod = "charValue";
+                break;
+            case 'F':
+                boxingInfo.boxedType = b.GetType("Ljava/lang/Float;");
+                boxingInfo.unboxMethod = "floatValue";
+                break;
+            case 'Z':
+                boxingInfo.boxedType = b.GetType("Ljava/lang/Boolean;");
+                boxingInfo.unboxMethod = "booleanValue";
+                break;
+            case 'J':
+                boxingInfo.boxedType = b.GetType("Ljava/lang/Long;");
+                boxingInfo.unboxMethod = "longValue";
+                break;
+            case 'D':
+                boxingInfo.boxedType = b.GetType("Ljava/lang/Double;");
+                boxingInfo.unboxMethod = "doubleValue";
+                break;
+            default:
+                // real object
+                break;
+        }
+
+        return boxingInfo;
+    }
+
+    static size_t
+    getNumParams(ir::EncodedMethod *method) {
+        if (method->decl->prototype->param_types == nullptr) {
+            return 0;
+        }
+
+        return method->decl->prototype->param_types->types.size();
+    }
+
+    static bool
+    canBeTransformed(ir::EncodedMethod *method) {
+        std::string type = method->decl->parent->Decl();
+        ir::String* methodName = method->decl->name;
+
+        return ((method->access_flags & kAccStatic) != 0)
+               && !(((method->access_flags & (kAccPrivate | kAccBridge | kAccNative)) != 0)
+                    || (Utf8Cmp(methodName->c_str(), "<clinit>") == 0)
+                    || (strncmp(type.c_str(), "java.", 5) == 0
+                        && (method->access_flags & (kAccPrivate | kAccPublic | kAccProtected))
+                           == 0));
+    }
+
+    // Transforms the classes to add the mockito hooks
+    // - equals and hashcode are handled in a special way
+    extern "C" JNIEXPORT jbyteArray JNICALL
+    Java_com_android_dx_mockito_inline_StaticClassTransformer_nativeRedefine(JNIEnv* env,
+                                                                           jobject generator,
+                                                                           jstring idStr,
+                                                                           jbyteArray originalArr) {
+        unsigned char* original = (unsigned char*)env->GetByteArrayElements(originalArr, 0);
+
+        Reader reader(original, env->GetArrayLength(originalArr));
+        reader.CreateClassIr(0);
+        std::shared_ptr<ir::DexFile> dex_ir = reader.GetIr();
+        ir::Builder b(dex_ir);
+
+        ir::Type* objectT = b.GetType("Ljava/lang/Object;");
+        ir::Type* objectArrayT = b.GetType("[Ljava/lang/Object;");
+        ir::Type* stringT = b.GetType("Ljava/lang/String;");
+        ir::Type* methodT = b.GetType("Ljava/lang/reflect/Method;");
+        ir::Type* callableT = b.GetType("Ljava/util/concurrent/Callable;");
+        ir::Type* dispatcherT = b.GetType("Lcom/android/dx/mockito/inline/MockMethodDispatcher;");
+
+        // Add id to dex file
+        const char* idNative = env->GetStringUTFChars(idStr, 0);
+        ir::String* id = b.GetAsciiString(idNative);
+        env->ReleaseStringUTFChars(idStr, idNative);
+
+        for (auto& method : dex_ir->encoded_methods) {
+            if (!canBeTransformed(method.get())) {
+                continue;
+            }
+            /*
+            static long method_original(int param1, long param2, String param3) {
+                foo();
+                return bar();
+            }
+
+            static long method_transformed(int param1, long param2, String param3) {
+                // MockMethodDispatcher dispatcher = MockMethodDispatcher.get(idStr, this);
+                const-string v0, "65463hg34t"
+                const v1, 0
+                invoke-static {v0, v1}, MockMethodDispatcher.get(String, Object):MockMethodDispatcher
+                move-result-object v0
+
+                // if (dispatcher == null) {
+                //    goto original_method;
+                // }
+                if-eqz v0, original_method
+
+                // Method origin = dispatcher.getOrigin(this, methodDesc);
+                const-string v1 "fully.qualified.ClassName#original_method(int, long, String)"
+                const v2, 0
+                invoke-virtual {v0, v2, v1}, MockMethodDispatcher.getOrigin(Object, String):Method
+                move-result-object v1
+
+                // if (origin == null) {
+                //     goto original_method;
+                // }
+                if-eqz v1, original_method
+
+                // Create an array with Objects of all parameters.
+
+                //     Object[] arguments = new Object[3]
+                const v3, 3
+                new-array v2, v3, Object[]
+
+                //     Integer param1Integer = Integer.valueOf(param1)
+                move-from16 v3, ARG1     # this is necessary as invoke-static cannot deal with high
+                                         # registers and ARG1 might be high
+                invoke-static {v3}, Integer.valueOf(int):Integer
+                move-result-object v3
+
+                //     arguments[0] = param1Integer
+                const v4, 0
+                aput-object v3, v2, v4
+
+                //     Long param2Long = Long.valueOf(param2)
+                move-widefrom16 v3:v4, ARG2.1:ARG2.2 # this is necessary as invoke-static cannot
+                                                     # deal with high registers and ARG2 might be
+                                                     # high
+                invoke-static {v3, v4}, Long.valueOf(long):Long
+                move-result-object v3
+
+                //     arguments[1] = param2Long
+                const v4, 1
+                aput-object v3, v2, v4
+
+                //     arguments[2] = param3
+                const v4, 2
+                move-objectfrom16 v3, ARG3     # this is necessary as aput-object cannot deal with
+                                               # high registers and ARG3 might be high
+                aput-object v3, v2, v4
+
+                // Callable<?> mocked = dispatcher.handle(methodDesc --as this parameter--,
+                //                                        origin, arguments);
+                const-string v3 "fully.qualified.ClassName#original_method(int, long, String)"
+                invoke-virtual {v0,v3,v1,v2}, MockMethodDispatcher.handle(Object, Method,
+                                                                          Object[]):Callable
+                move-result-object v0
+
+                //  if (mocked != null) {
+                if-eqz v0, original_method
+
+                //      Object ret = mocked.call();
+                invoke-interface {v0}, Callable.call():Object
+                move-result-object v0
+
+                //      Long retLong = (Long)ret
+                check-cast v0, Long
+
+                //      long retlong = retLong.longValue();
+                invoke-virtual {v0}, Long.longValue():long
+                move-result-wide v0:v1
+
+                //      return retlong;
+                return-wide v0:v1
+
+                //  }
+
+            original_method:
+                // Move all method arguments down so that they match what the original code expects.
+                // Let's assume three arguments, one int, one long, one String and the and used to
+                // use 4 registers
+                move16 v5, v6             # ARG1
+                move-wide16 v6:v7, v7:v8  # ARG2 (overlapping moves are allowed)
+                move-object16 v8, v9      # ARG3
+
+                // foo();
+                // return bar();
+                unmodified original byte code
+            }
+            */
+
+            CodeIr c(method.get(), dex_ir);
+
+            // Make sure there are at least 5 local registers to use
+            int originalNumRegisters = method->code->registers - method->code->ins_count;
+            int numAdditionalRegs = std::max(0, 5 - originalNumRegisters);
+            int firstArg = originalNumRegisters + numAdditionalRegs;
+
+            if (numAdditionalRegs > 0) {
+                c.ir_method->code->registers += numAdditionalRegs;
+            }
+
+            lir::Instruction* fi = *(c.instructions.begin());
+
+            // Add methodDesc to dex file
+            std::stringstream ss;
+            ss << method->decl->parent->Decl() << "#" << method->decl->name->c_str() << "(" ;
+            bool first = true;
+            if (method->decl->prototype->param_types != nullptr) {
+                for (const auto& type : method->decl->prototype->param_types->types) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        ss << ",";
+                    }
+
+                    ss << type->Decl().c_str();
+                }
+            }
+            ss << ")";
+            std::string methodDescStr = ss.str();
+            ir::String* methodDesc = b.GetAsciiString(methodDescStr.c_str());
+
+            size_t numParams = getNumParams(method.get());
+
+            Label* originalMethodLabel = c.Alloc<Label>(0);
+            CodeLocation* originalMethod = c.Alloc<CodeLocation>(originalMethodLabel);
+            VReg* v0 = c.Alloc<VReg>(0);
+            VReg* v1 = c.Alloc<VReg>(1);
+            VReg* v2 = c.Alloc<VReg>(2);
+            VReg* v3 = c.Alloc<VReg>(3);
+            VReg* v4 = c.Alloc<VReg>(4);
+
+            addInstr(c, fi, OP_CONST_STRING, {v0, c.Alloc<String>(id, id->orig_index)});
+            addInstr(c, fi, OP_CONST, {v1, c.Alloc<Const32>(0)});
+            addCall(b, c, fi, OP_INVOKE_STATIC, dispatcherT, "get", dispatcherT, {stringT, objectT},
+                    {0, 1});
+            addInstr(c, fi, OP_MOVE_RESULT_OBJECT, {v0});
+            addInstr(c, fi, OP_IF_EQZ, {v0, originalMethod});
+            addInstr(c, fi, OP_CONST_STRING,
+                     {v1, c.Alloc<String>(methodDesc, methodDesc->orig_index)});
+            addInstr(c, fi, OP_CONST, {v2, c.Alloc<Const32>(0)});
+            addCall(b, c, fi, OP_INVOKE_VIRTUAL, dispatcherT, "getOrigin", methodT,
+                    {objectT, stringT}, {0, 2, 1});
+            addInstr(c, fi, OP_MOVE_RESULT_OBJECT, {v1});
+            addInstr(c, fi, OP_IF_EQZ, {v1, originalMethod});
+            addInstr(c, fi, OP_CONST, {v3, c.Alloc<Const32>(numParams)});
+            addInstr(c, fi, OP_NEW_ARRAY, {v2, v3, c.Alloc<Type>(objectArrayT,
+                                                                 objectArrayT->orig_index)});
+
+            if (numParams > 0) {
+                int argReg = firstArg;
+
+                for (int argNum = 0; argNum < numParams; argNum++) {
+                    const auto& type = method->decl->prototype->param_types->types[argNum];
+                    BoxingInfo boxingInfo = getBoxingInfo(b, type->descriptor->c_str()[0]);
+
+                    switch (type->GetCategory()) {
+                        case ir::Type::Category::Scalar:
+                            addInstr(c, fi, OP_MOVE_FROM16, {v3, c.Alloc<VReg>(argReg)});
+                            addCall(b, c, fi, OP_INVOKE_STATIC, boxingInfo.boxedType, "valueOf",
+                                    boxingInfo.boxedType, {type}, {3});
+                            addInstr(c, fi, OP_MOVE_RESULT_OBJECT, {v3});
+
+                            argReg++;
+                            break;
+                        case ir::Type::Category::WideScalar: {
+                            VRegPair* v3v4 = c.Alloc<VRegPair>(3);
+                            VRegPair* argRegPair = c.Alloc<VRegPair>(argReg);
+
+                            addInstr(c, fi, OP_MOVE_WIDE_FROM16, {v3v4, argRegPair});
+                            addCall(b, c, fi, OP_INVOKE_STATIC, boxingInfo.boxedType, "valueOf",
+                                    boxingInfo.boxedType, {type}, {3, 4});
+                            addInstr(c, fi, OP_MOVE_RESULT_OBJECT, {v3});
+
+                            argReg += 2;
+                            break;
+                        }
+                        case ir::Type::Category::Reference:
+                            addInstr(c, fi, OP_MOVE_OBJECT_FROM16, {v3, c.Alloc<VReg>(argReg)});
+
+                            argReg++;
+                            break;
+                        case ir::Type::Category::Void:
+                            assert(false);
+                    }
+
+                    addInstr(c, fi, OP_CONST, {v4, c.Alloc<Const32>(argNum)});
+                    addInstr(c, fi, OP_APUT_OBJECT, {v3, v2, v4});
+                }
+            }
+
+            // NASTY Hack: Push in method name as "mock"
+            addInstr(c, fi, OP_CONST_STRING,
+                     {v3, c.Alloc<String>(methodDesc, methodDesc->orig_index)});
+            addCall(b, c, fi, OP_INVOKE_VIRTUAL, dispatcherT, "handle", callableT,
+                    {objectT, methodT, objectArrayT}, {0, 3, 1, 2});
+            addInstr(c, fi, OP_MOVE_RESULT_OBJECT, {v0});
+            addInstr(c, fi, OP_IF_EQZ, {v0, originalMethod});
+            addCall(b, c, fi, OP_INVOKE_INTERFACE, callableT, "call", objectT, {}, {0});
+            addInstr(c, fi, OP_MOVE_RESULT_OBJECT, {v0});
+
+            ir::Type *returnType = method->decl->prototype->return_type;
+            BoxingInfo boxingInfo = getBoxingInfo(b, returnType->descriptor->c_str()[0]);
+
+            switch (returnType->GetCategory()) {
+                case ir::Type::Category::Scalar:
+                    addInstr(c, fi, OP_CHECK_CAST, {v0,
+                                                    c.Alloc<Type>(boxingInfo.boxedType, boxingInfo.boxedType->orig_index)});
+                    addCall(b, c, fi, OP_INVOKE_VIRTUAL, boxingInfo.boxedType,
+                            boxingInfo.unboxMethod.c_str(), returnType, {}, {0});
+                    addInstr(c, fi, OP_MOVE_RESULT, {v0});
+                    addInstr(c, fi, OP_RETURN, {v0});
+                    break;
+                case ir::Type::Category::WideScalar: {
+                    VRegPair* v0v1 = c.Alloc<VRegPair>(0);
+
+                    addInstr(c, fi, OP_CHECK_CAST, {v0,
+                                                    c.Alloc<Type>(boxingInfo.boxedType, boxingInfo.boxedType->orig_index)});
+                    addCall(b, c, fi, OP_INVOKE_VIRTUAL, boxingInfo.boxedType,
+                            boxingInfo.unboxMethod.c_str(), returnType, {}, {0});
+                    addInstr(c, fi, OP_MOVE_RESULT_WIDE, {v0v1});
+                    addInstr(c, fi, OP_RETURN_WIDE, {v0v1});
+                    break;
+                }
+                case ir::Type::Category::Reference:
+                    addInstr(c, fi, OP_CHECK_CAST, {v0, c.Alloc<Type>(returnType,
+                                                                      returnType->orig_index)});
+                    addInstr(c, fi, OP_RETURN_OBJECT, {v0});
+                    break;
+                case ir::Type::Category::Void:
+                    addInstr(c, fi, OP_RETURN_VOID, {});
+                    break;
+            }
+
+            addLabel(c, fi, originalMethodLabel);
+
+            if (numParams > 0) {
+                int argReg = firstArg;
+
+                for (int argNum = 0; argNum < numParams; argNum++) {
+                    const auto& type = method->decl->prototype->param_types->types[argNum];
+                    int origReg = argReg - numAdditionalRegs;
+                    switch (type->GetCategory()) {
+                        case ir::Type::Category::Scalar:
+                            addInstr(c, fi, OP_MOVE_16, {c.Alloc<VReg>(origReg),
+                                                         c.Alloc<VReg>(argReg)});
+                            argReg++;
+                            break;
+                        case ir::Type::Category::WideScalar:
+                            addInstr(c, fi, OP_MOVE_WIDE_16,{c.Alloc<VRegPair>(origReg),
+                                                             c.Alloc<VRegPair>(argReg)});
+                            argReg +=2;
+                            break;
+                        case ir::Type::Category::Reference:
+                            addInstr(c, fi, OP_MOVE_OBJECT_16, {c.Alloc<VReg>(origReg),
+                                                                c.Alloc<VReg>(argReg)});
+                            argReg++;
+                            break;
+                    }
+                }
+            }
+
+            c.Assemble();
+        }
+
+        struct Allocator : public Writer::Allocator {
+            virtual void* Allocate(size_t size) {return ::malloc(size);}
+            virtual void Free(void* ptr) {::free(ptr);}
+        };
+
+        Allocator allocator;
+        Writer writer(dex_ir);
+        size_t transformedLen = 0;
+        std::shared_ptr<jbyte> transformed((jbyte*)writer.CreateImage(&allocator, &transformedLen));
+
+        jbyteArray transformedArr = env->NewByteArray(transformedLen);
+        env->SetByteArrayRegion(transformedArr, 0, transformedLen, transformed.get());
+
+        return transformedArr;
+    }
+
+    // Initializes the agent
+    extern "C" jint Agent_OnAttach(JavaVM* vm,
+                                   char* options,
+                                   void* reserved) {
+        jint jvmError = vm->GetEnv(reinterpret_cast<void**>(&localJvmtiEnv), JVMTI_VERSION_1_2);
+        if (jvmError != JNI_OK) {
+            return jvmError;
+        }
+
+        jvmtiCapabilities caps;
+        memset(&caps, 0, sizeof(caps));
+        caps.can_retransform_classes = 1;
+
+        jvmtiError error = localJvmtiEnv->AddCapabilities(&caps);
+        if (error != JVMTI_ERROR_NONE) {
+            return error;
+        }
+
+        jvmtiEventCallbacks cb;
+        memset(&cb, 0, sizeof(cb));
+        cb.ClassFileLoadHook = Transform;
+
+        error = localJvmtiEnv->SetEventCallbacks(&cb, sizeof(cb));
+        if (error != JVMTI_ERROR_NONE) {
+            return error;
+        }
+
+        error = localJvmtiEnv->SetEventNotificationMode(JVMTI_ENABLE,
+                                                        JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, nullptr);
+        if (error != JVMTI_ERROR_NONE) {
+            return error;
+        }
+
+        return JVMTI_ERROR_NONE;
+    }
+
+    // Throw runtime exception
+    static void throwRuntimeExpection(JNIEnv* env, const char* fmt, ...) {
+        char msgBuf[512];
+
+        va_list args;
+        va_start (args, fmt);
+        vsnprintf(msgBuf, sizeof(msgBuf), fmt, args);
+        va_end (args);
+
+        jclass exceptionClass = env->FindClass("java/lang/RuntimeException");
+        env->ThrowNew(exceptionClass, msgBuf);
+    }
+
+    // Register transformer hook
+    extern "C" JNIEXPORT void JNICALL
+    Java_com_android_dx_mockito_inline_StaticJvmtiAgent_nativeRegisterTransformerHook(JNIEnv* env,
+                                                                                     jobject thiz) {
+        sTransformer = env->NewGlobalRef(thiz);
+    }
+
+    // Unregister transformer hook
+    extern "C" JNIEXPORT void JNICALL
+    Java_com_android_dx_mockito_inline_StaticJvmtiAgent_nativeUnregisterTransformerHook(JNIEnv* env,
+                                                                                     jobject thiz) {
+        env->DeleteGlobalRef(sTransformer);
+        sTransformer = nullptr;
+    }
+
+    // Triggers retransformation of classes via this file's Transform method
+    extern "C" JNIEXPORT void JNICALL
+    Java_com_android_dx_mockito_inline_StaticJvmtiAgent_nativeRetransformClasses(JNIEnv* env,
+                                                                             jobject thiz,
+                                                                             jobjectArray classes) {
+        jsize numTransformedClasses = env->GetArrayLength(classes);
+        jclass *transformedClasses = (jclass*) malloc(numTransformedClasses * sizeof(jclass));
+        for (int i = 0; i < numTransformedClasses; i++) {
+            transformedClasses[i] = (jclass) env->NewGlobalRef(env->GetObjectArrayElement(classes, i));
+        }
+
+        jvmtiError error = localJvmtiEnv->RetransformClasses(numTransformedClasses,
+                                                             transformedClasses);
+
+        for (int i = 0; i < numTransformedClasses; i++) {
+            env->DeleteGlobalRef(transformedClasses[i]);
+        }
+        free(transformedClasses);
+
+        if (error != JVMTI_ERROR_NONE) {
+            throwRuntimeExpection(env, "Could not retransform classes: %d", error);
+        }
+    }
+
+    static jvmtiFrameInfo* frameToInspect;
+    static std::string calledClass;
+
+    // Takes the full dex file for class 'classBeingRedefined'
+    // - isolates the dex code for the class out of the dex file
+    // - calls sTransformer.runTransformers on the isolated dex code
+    // - send the transformed code back to the runtime
+    static void
+    InspectClass(jvmtiEnv* jvmtiEnv,
+                 JNIEnv* env,
+                 jclass classBeingRedefined,
+                 jobject loader,
+                 const char* name,
+                 jobject protectionDomain,
+                 jint classDataLen,
+                 const unsigned char* classData,
+                 jint* newClassDataLen,
+                 unsigned char** newClassData) {
+        calledClass = "none";
+
+        Reader reader(classData, classDataLen);
+
+        char *calledMethodName;
+        char *calledMethodSignature;
+        jvmtiError error = jvmtiEnv->GetMethodName(frameToInspect->method, &calledMethodName,
+                                                   &calledMethodSignature, nullptr);
+        if (error != JVMTI_ERROR_NONE) {
+            return;
+        }
+
+        u4 index = reader.FindClassIndex(ClassNameToDescriptor(name).c_str());
+        reader.CreateClassIr(index);
+        std::shared_ptr<ir::DexFile> class_ir = reader.GetIr();
+
+        for (auto& method : class_ir->encoded_methods) {
+            if (Utf8Cmp(method->decl->name->c_str(), calledMethodName) == 0
+                && Utf8Cmp(method->decl->prototype->Signature().c_str(), calledMethodSignature) == 0) {
+                CodeIr method_ir(method.get(), class_ir);
+
+                for (auto instruction : method_ir.instructions) {
+                    Bytecode* bytecode = dynamic_cast<Bytecode*>(instruction);
+                    if (bytecode != nullptr && bytecode->offset == frameToInspect->location) {
+                        Method *method = bytecode->CastOperand<Method>(1);
+                        calledClass = method->ir_method->parent->Decl().c_str();
+
+                        goto exit;
+                    }
+                }
+            }
+        }
+
+        exit:
+        free(calledMethodName);
+        free(calledMethodSignature);
+    }
+
+#define GOTO_ON_ERROR(label) \
+    if (error != JVMTI_ERROR_NONE) { \
+        goto label; \
+    }
+
+// stack frame of the caller if method was called directly
+#define DIRECT_CALL_STACK_FRAME (6)
+
+// stack frame of the caller if method was called as 'real method'
+#define REALMETHOD_CALL_STACK_FRAME (23)
+
+    extern "C" JNIEXPORT jstring JNICALL
+    Java_com_android_dx_mockito_inline_StaticMockMethodAdvice_nativeGetCalledClassName(JNIEnv* env,
+                                                                                     jclass klass) {
+        JavaVM *vm;
+        jint jvmError = env->GetJavaVM(&vm);
+        if (jvmError != JNI_OK) {
+            return nullptr;
+        }
+
+        jvmtiEnv *jvmtiEnv;
+        jvmError = vm->GetEnv(reinterpret_cast<void**>(&jvmtiEnv), JVMTI_VERSION_1_2);
+        if (jvmError != JNI_OK) {
+            return nullptr;
+        }
+
+        jvmtiCapabilities caps;
+        memset(&caps, 0, sizeof(caps));
+        caps.can_retransform_classes = 1;
+
+        jvmtiError error = jvmtiEnv->AddCapabilities(&caps);
+        GOTO_ON_ERROR(unregister_env_and_exit);
+
+        jvmtiEventCallbacks cb;
+        memset(&cb, 0, sizeof(cb));
+        cb.ClassFileLoadHook = InspectClass;
+
+        jvmtiFrameInfo frameInfo[REALMETHOD_CALL_STACK_FRAME + 1];
+        jint numFrames;
+        error = jvmtiEnv->GetStackTrace(nullptr, 0, REALMETHOD_CALL_STACK_FRAME + 1, frameInfo,
+                                        &numFrames);
+        GOTO_ON_ERROR(unregister_env_and_exit);
+
+        // Method might be called directly or as 'real method' (see
+        // StaticMockMethodAdvice.SuperMethodCall#invoke). Hence the real caller might be in stack
+        // frame DIRECT_CALL_STACK_FRAME for a direct call or REALMETHOD_CALL_STACK_FRAME for a
+        // call through the 'real method' mechanism.
+        int callingFrameNum;
+        if (numFrames < REALMETHOD_CALL_STACK_FRAME) {
+            callingFrameNum = DIRECT_CALL_STACK_FRAME;
+        } else {
+            char *directCallMethodName;
+
+            jvmtiEnv->GetMethodName(frameInfo[DIRECT_CALL_STACK_FRAME].method,
+                                    &directCallMethodName, nullptr, nullptr);
+            if (strcmp(directCallMethodName, "invoke") == 0) {
+                callingFrameNum = REALMETHOD_CALL_STACK_FRAME;
+            } else {
+                callingFrameNum = DIRECT_CALL_STACK_FRAME;
+            }
+        }
+
+        jclass callingClass;
+        error = jvmtiEnv->GetMethodDeclaringClass(frameInfo[callingFrameNum].method, &callingClass);
+        GOTO_ON_ERROR(unregister_env_and_exit);
+
+        error = jvmtiEnv->SetEventCallbacks(&cb, sizeof(cb));
+        GOTO_ON_ERROR(unregister_env_and_exit);
+
+        error = jvmtiEnv->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                                   nullptr);
+        GOTO_ON_ERROR(unset_cb_and_exit);
+
+        frameToInspect = &frameInfo[callingFrameNum];
+        error = jvmtiEnv->RetransformClasses(1, &callingClass);
+        GOTO_ON_ERROR(disable_hook_and_exit);
+
+        disable_hook_and_exit:
+        jvmtiEnv->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                           nullptr);
+
+        unset_cb_and_exit:
+        memset(&cb, 0, sizeof(cb));
+        jvmtiEnv->SetEventCallbacks(&cb, sizeof(cb));
+
+        unregister_env_and_exit:
+        jvmtiEnv->DisposeEnvironment();
+
+        if (error != JVMTI_ERROR_NONE) {
+            return nullptr;
+        }
+
+        return env->NewStringUTF(calledClass.c_str());
+    }
+
+}  // namespace com_android_dx_mockito_inline
+

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/ClassTransformer.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/ClassTransformer.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 
 /**
@@ -59,7 +58,6 @@ class ClassTransformer {
                     Float.class,
                     Double.class,
                     String.class));
-    private final static Random random = new Random();
 
     /** Jvmti agent responsible for triggering transformation s*/
     private final JvmtiAgent agent;
@@ -99,7 +97,7 @@ class ClassTransformer {
                      Map<Object, InvocationHandlerAdapter> mocks) {
         this.agent = agent;
         mockedTypes = Collections.synchronizedSet(new HashSet<Class<?>>());
-        identifier = Long.toString(random.nextLong());
+        identifier = String.valueOf(System.identityHashCode(this));
         MockMethodAdvice advice = new MockMethodAdvice(mocks);
 
         try {

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/DexmakerStackTraceCleaner.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/DexmakerStackTraceCleaner.java
@@ -40,7 +40,8 @@ public final class DexmakerStackTraceCleaner implements StackTraceCleanerProvide
                         && !(className.startsWith("com.android.dx.mockito.")
                              // Do not clean unit tests
                              && !className.startsWith("com.android.dx.mockito.tests")
-                             && !className.startsWith("com.android.dx.mockito.inline.tests"))
+                             && !className.startsWith("com.android.dx.mockito.inline.tests")
+                             && !className.startsWith("com.android.dx.mockito.inline.extended.tests"))
 
                         // dalvik interface proxies
                         && !className.startsWith("$Proxy")

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InlineDexmakerMockMaker.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InlineDexmakerMockMaker.java
@@ -67,7 +67,7 @@ public final class InlineDexmakerMockMaker implements MockMaker {
      * Class injected into the bootstrap classloader. All entry hooks added to methods will call
      * this class.
      */
-    private static final Class DISPATCHER_CLASS;
+    public static final Class DISPATCHER_CLASS;
 
     /*
      * One time setup to allow the system to mocking via this mock maker.

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline;
+
+import org.mockito.invocation.MockHandler;
+import org.mockito.mock.MockCreationSettings;
+import org.mockito.plugins.MockMaker;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+
+/**
+ * Multiplexes multiple mock makers
+ */
+public final class MockMakerMultiplexer implements MockMaker {
+    private final static MockMaker[] MOCK_MAKERS;
+
+    static {
+        String[] potentialMockMakers = new String[] {
+                InlineDexmakerMockMaker.class.getName()
+        };
+
+        ArrayList<MockMaker> mockMakers = new ArrayList<>();
+        for (String potentialMockMaker : potentialMockMakers) {
+            try {
+                Class<? extends MockMaker> mockMakerClass = (Class<? extends MockMaker>)
+                        Class.forName(potentialMockMaker);
+                mockMakers.add(mockMakerClass.getDeclaredConstructor().newInstance());
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+            } catch (InstantiationException e) {
+                e.printStackTrace();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (NoSuchMethodException e) {
+                e.printStackTrace();
+            } catch (InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+
+        MOCK_MAKERS = mockMakers.toArray(new MockMaker[]{});
+    }
+
+    @Override
+    public <T> T createMock(MockCreationSettings<T> settings, MockHandler handler) {
+        for (MockMaker mockMaker : MOCK_MAKERS) {
+            T mock = mockMaker.createMock(settings, handler);
+
+            if (mock != null) {
+                return mock;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public MockHandler getHandler(Object mock) {
+        for (MockMaker mockMaker : MOCK_MAKERS) {
+            MockHandler handler = mockMaker.getHandler(mock);
+
+            if (handler != null) {
+                return handler;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void resetMock(Object mock, MockHandler newHandler, MockCreationSettings settings) {
+        for (MockMaker mockMaker : MOCK_MAKERS) {
+            mockMaker.resetMock(mock, newHandler, settings);
+        }
+    }
+
+    @Override
+    public TypeMockability isTypeMockable(Class<?> type) {
+        for (MockMaker mockMaker : MOCK_MAKERS) {
+            TypeMockability mockability = mockMaker.isTypeMockable(type);
+
+            if (mockability != null) {
+                return mockability;
+            }
+        }
+
+        return null;
+    }
+}

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
@@ -31,6 +31,7 @@ public final class MockMakerMultiplexer implements MockMaker {
 
     static {
         String[] potentialMockMakers = new String[] {
+                "com.android.dx.mockito.inline.InlineStaticMockMaker",
                 InlineDexmakerMockMaker.class.getName()
         };
 

--- a/dexmaker-mockito-inline/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dexmaker-mockito-inline/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,1 @@
-com.android.dx.mockito.inline.InlineDexmakerMockMaker
+com.android.dx.mockito.inline.MockMakerMultiplexer

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,5 @@
 rootProject.name = "dexmaker-root"
-include ':dexmaker', ':dexmaker-tests', ':dexmaker-mockito', ':dexmaker-mockito-tests', ':dexmaker-mockito-inline-dispatcher', ':dexmaker-mockito-inline', ':dexmaker-mockito-inline-tests', ':dexmaker-mockito-tests'
+include ':dexmaker', ':dexmaker-tests', ':dexmaker-mockito', ':dexmaker-mockito-tests',
+        ':dexmaker-mockito-inline-dispatcher', ':dexmaker-mockito-inline',
+        ':dexmaker-mockito-inline-tests', ':dexmaker-mockito-tests',
+        ':dexmaker-mockito-inline-extended', ':dexmaker-mockito-inline-extended-tests'


### PR DESCRIPTION
This adds a wrapper for Mockito called ExtendedMockito that allows for stubbing of static methods on an Android P(or later) JVM.