### PR TITLE
Disable Gradle configureondemand - Fixes #101

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,9 @@
 org.gradle.jvmargs=-Djava.awt.headless=true
 org.gradle.parallel=true
 
+# Disabling due to https://github.com/JFrogDev/build-info/issues/86
+org.gradle.configureondemand=false
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
Configuration on demand + the JFrog plugin seems to cause
Gradle sync issues in Android Studio. Disabling this option
and disabling the Configure on Demand setting in Android Studio
preferences fixes the issue.

This project doesn't need Configure on Demand anyway, so there's
no downside to disabling this option, even if Gradle and JFrog
come up with a different workaround later.

For more details, see:
https://github.com/JFrogDev/build-info/issues/86