### PR TITLE
Add spyOn(Object) that allows to turn existing object into a spy

### DIFF
--- a/dexmaker-mockito-inline-extended-tests/build.gradle
+++ b/dexmaker-mockito-inline-extended-tests/build.gradle
@@ -47,5 +47,7 @@ dependencies {
 
     implementation 'junit:junit:4.12'
     implementation 'com.android.support.test:runner:1.0.1'
+    implementation 'com.android.support.test:rules:1.0.2'
+
     api 'org.mockito:mockito-core:2.16.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline-extended-tests/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-inline-extended-tests/src/main/AndroidManifest.xml
@@ -1,1 +1,7 @@
-<manifest package="com.android.dexmaker.mockito.inline.extended.tests" />
+<manifest package="com.android.dexmaker.mockito.inline.extended.tests"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity android:name="com.android.dx.mockito.inline.extended.tests.EmptyActivity" />
+    </application>
+</manifest>

--- a/dexmaker-mockito-inline-extended-tests/src/main/java/com/android/dx/mockito/inline/extended/tests/EmptyActivity.java
+++ b/dexmaker-mockito-inline-extended-tests/src/main/java/com/android/dx/mockito/inline/extended/tests/EmptyActivity.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended.tests;
+
+import android.app.Activity;
+
+public class EmptyActivity extends Activity {
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+    }
+}

--- a/dexmaker-mockito-inline-extended-tests/src/main/java/com/android/dx/mockito/inline/extended/tests/SpyOn.java
+++ b/dexmaker-mockito-inline-extended-tests/src/main/java/com/android/dx/mockito/inline/extended/tests/SpyOn.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.extended.tests;
+
+import android.app.Instrumentation;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.doAnswer;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.mock;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.spy;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.spyOn;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.verify;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.when;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+@RunWith(AndroidJUnit4.class)
+public class SpyOn {
+    @Rule
+    public ActivityTestRule<EmptyActivity> activityRule =
+            new ActivityTestRule<>(EmptyActivity.class);
+
+    public class TestClass {
+        Object field;
+
+        public String echo(String in) {
+            return in;
+        }
+    }
+
+    @Test
+    public void spyOnLocalClass() {
+        TestClass t = new TestClass();
+        assertEquals("one", t.echo("one"));
+
+        spyOn(t);
+        assertEquals("two", t.echo("two"));
+        verify(t).echo("two");
+
+        when(t.echo("three")).thenReturn("not three");
+        assertEquals("not three", t.echo("three"));
+        verify(t).echo("three");
+    }
+
+    @Test
+    public void localFieldStaysTheSame() {
+        TestClass t = new TestClass();
+
+        Object marker = mock(Object.class);
+        t.field = marker;
+
+        spyOn(t);
+        assertSame(marker, t.field);
+    }
+
+    @Test
+    public void spiesAreUsuallyClones() {
+        TestClass original = new TestClass();
+
+        Object marker = new Object();
+        original.field = marker;
+
+        TestClass spy = spy(original);
+        assertSame(marker, spy.field);
+
+        assertNotSame(original, spy);
+    }
+
+    @Test
+    public void spyOnActivity() throws Exception {
+        EmptyActivity a = activityRule.getActivity();
+        spyOn(a);
+
+        // Intercept a#onDestroy(). The first time this is called isDestroyed[0] is set to true,
+        // the second time it is called, it calls the real method.
+        boolean isDestroyed[] = new boolean[]{false};
+        doAnswer((inv) -> {
+            synchronized (isDestroyed) {
+                isDestroyed[0] = true;
+                isDestroyed.notifyAll();
+            }
+
+            // Call a second time to call super method before returning. Android requires onDestroy
+            // to always call it's super-method.
+            a.onDestroy();
+            return null;
+        }).doCallRealMethod().when(a).onDestroy();
+
+        activityRule.finishActivity();
+
+        synchronized (isDestroyed) {
+            while (!isDestroyed[0]) {
+                isDestroyed.wait();
+            }
+        }
+    }
+}

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/ExtendedMockito.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/ExtendedMockito.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.android.dx.mockito.inline.InlineDexmakerMockMaker.onSpyInProgressInstance;
 import static com.android.dx.mockito.inline.InlineStaticMockMaker.onMethodCallDuringVerification;
 import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress;
 
@@ -192,6 +193,20 @@ public class ExtendedMockito extends Mockito {
         }
 
         return markers;
+    }
+
+    public static void spyOn(Object toMock) {
+        if (onSpyInProgressInstance.get() != null) {
+            throw new IllegalStateException("Cannot set up spying on an existing object while "
+                    + "setting up spying for another existing object");
+        }
+
+        onSpyInProgressInstance.set(toMock);
+        try {
+            spy(toMock);
+        } finally {
+            onSpyInProgressInstance.remove();
+        }
     }
 
     /**


### PR DESCRIPTION
This is meant to solve the problem that certain Android objects (e.g.
Activities) need to be created by the system to be useful.

While this is a feature of the ExtendedMockito it has a hook into
InlineDexmakerMockMaker. The other option would be to add a full inline
dexmaker mock maker only for this feature.