### PR TITLE
Do not reference abstract super methods

### DIFF
--- a/dexmaker-mockito-tests/src/main/java/com/android/dx/mockito/tests/PartialClasses.java
+++ b/dexmaker-mockito-tests/src/main/java/com/android/dx/mockito/tests/PartialClasses.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.tests;
+
+import org.junit.Test;
+import org.mockito.exceptions.base.MockitoException;
+
+import java.util.AbstractList;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests what happens if code tries to call real methods of abstract classed and in interfaces
+ */
+public class PartialClasses {
+    @Test
+    public void callRealMethodOnInterface() {
+        Runnable r = mock(Runnable.class);
+
+        try {
+            doCallRealMethod().when(r).run();
+            fail();
+        } catch (MockitoException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void callAbstractRealMethodOnAbstractClass() {
+        AbstractList l = mock(AbstractList.class);
+
+        try {
+            when(l.size()).thenCallRealMethod();
+            fail();
+        } catch (MockitoException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void callRealMethodOnAbstractClass() {
+        AbstractList l = mock(AbstractList.class);
+
+        doCallRealMethod().when(l).clear();
+
+        l.clear();
+    }
+}

--- a/dexmaker-tests/src/androidTest/java/com/android/dx/AnnotationIdTest.java
+++ b/dexmaker-tests/src/androidTest/java/com/android/dx/AnnotationIdTest.java
@@ -15,6 +15,7 @@
  */
 package com.android.dx;
 
+import android.os.Build;
 import android.support.test.InstrumentationRegistry;
 import org.junit.After;
 import org.junit.Before;
@@ -31,6 +32,7 @@ import static com.android.dx.TypeId.*;
 import static java.lang.reflect.Modifier.PUBLIC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 public final class AnnotationIdTest {
 
@@ -227,6 +229,8 @@ public final class AnnotationIdTest {
      */
     @Test
     public void addMethodAnnotationWithEnumElement() throws Exception {
+        assumeTrue(Build.VERSION.SDK_INT >= 21);
+
         MethodId<?, Void> methodId = generateVoidMethod(TypeId.get(Enum.class));
         AnnotationId.Element element = new AnnotationId.Element("elementEnum", ElementEnum.INSTANCE_1);
         addAnnotationToMethod(methodId, element);
@@ -259,6 +263,8 @@ public final class AnnotationIdTest {
      */
     @Test
     public void addMethodAnnotationWithMultiElements() throws Exception {
+        assumeTrue(Build.VERSION.SDK_INT >= 21);
+
         MethodId<?, Void> methodId = generateVoidMethod();
         AnnotationId.Element element1 = new AnnotationId.Element("elementClass", AnnotationId.class);
         AnnotationId.Element element2 = new AnnotationId.Element("elementEnum", ElementEnum.INSTANCE_1);
@@ -280,6 +286,8 @@ public final class AnnotationIdTest {
      */
     @Test
     public void addMethodAnnotationWithDuplicateElements() throws Exception {
+        assumeTrue(Build.VERSION.SDK_INT >= 21);
+
         MethodId<?, Void> methodId = generateVoidMethod();
         AnnotationId.Element element1 = new AnnotationId.Element("elementEnum", ElementEnum.INSTANCE_1);
         AnnotationId.Element element2 = new AnnotationId.Element("elementEnum", ElementEnum.INSTANCE_0);


### PR DESCRIPTION
In API 19 and below generating code that calls abstract super methods
may cause verification errors.

This effect is only seen if the code was originally compiled against a
higher SDK level that had the method, but then the code was run against
a lower SDK level that does not have the method. This is a trick
androidx (aka. the android support library) is commonly using.

There is really no point of even generating the code that calls the
abstract super method, hence this change replaces the calling code by a
throw(new AbstractMethodError("'method' cannot be called').

The code referenced in ProxyBuilder#generateCodeForAllMethods was not
complete and making it complete would make it much more complicated.
Hence I removed it. If somebody wants to look at the actually
generated code, they can use 'dexdump -d' on the generated dex file.

Mockito handles attempts to call the real abstract method gracefully. It
does not even allow to set up such a stubbing.

Bonus:
- Added test for shared classloader functionality of the proxy builder
- I checked all way back to API19 and made sure that tests that cannot
  run on older API levels are ignored