### PR TITLE
Set up dexmaker-mockito-inline-extended for publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,5 +45,5 @@ artifactory {
 }
 
 task distributeBuild(type: DistributeTask) {
-    dependsOn ':artifactoryPublish', 'dexmaker:artifactoryPublish', 'dexmaker-mockito:artifactoryPublish', 'dexmaker-mockito-inline:artifactoryPublish'
+    dependsOn ':artifactoryPublish', 'dexmaker:artifactoryPublish', 'dexmaker-mockito:artifactoryPublish', 'dexmaker-mockito-inline:artifactoryPublish', 'dexmaker-mockito-inline-extended:artifactoryPublish'
 }

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -11,6 +11,11 @@ buildscript {
 
 apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.library'
+apply plugin: 'maven-publish'
+apply plugin: 'ivy-publish'
+apply plugin: 'com.jfrog.artifactory'
+
+version = VERSION_NAME
 
 android {
     compileSdkVersion 28
@@ -43,6 +48,67 @@ android {
 
 tasks.withType(JavaCompile) {
     options.compilerArgs += ["-Xep:StringSplitter:OFF"]
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    failOnError false
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+publishing {
+    publications {
+        ivyLib(IvyPublication) {
+            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.implementation.getAllDependencies())
+            artifact sourcesJar
+            artifact javadocJar
+        }
+
+        lib(MavenPublication) {
+            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.implementation.getAllDependencies())
+
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom.withXml {
+                asNode().children().last() + {
+                    resolveStrategy = Closure.DELEGATE_FIRST
+                    description = 'Extension of the Mockito Inline API to allow mocking static methods on the Android Dalvik VM'
+                    url 'https://github.com/linkedin/dexmaker'
+                    scm {
+                        url 'https://github.com/linkedin/dexmaker'
+                        connection 'scm:git:git://github.com/linkedin/dexmaker.git'
+                        developerConnection 'https://github.com/linkedin/dexmaker.git'
+                    }
+                    licenses {
+                        license {
+                            name 'The Apache Software License, Version 2.0'
+                            url 'http://www.apache.org/license/LICENSE-2.0.txt'
+                            distribution 'repo'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id 'com.linkedin'
+                            name 'LinkedIn Corp'
+                            email ''
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 repositories {


### PR DESCRIPTION
Tested this change by running :dexmaker-mockito-inline-extended:publishToMavenLocal
and checking that the generated pom file included the
proper dependencies.