### PR TITLE
Allow starting of static-spy-session for objects without 0-arg constructor

### DIFF
--- a/dexmaker-mockito-inline-extended-tests/src/main/java/com/android/dx/mockito/inline/extended/tests/MockStatic.java
+++ b/dexmaker-mockito-inline-extended-tests/src/main/java/com/android/dx/mockito/inline/extended/tests/MockStatic.java
@@ -73,6 +73,18 @@ public class MockStatic {
         }
     }
 
+    private static class NoDefaultConstructorClass {
+        private static int mLastId;
+
+        NoDefaultConstructorClass(int id) {
+            mLastId = id;
+        }
+
+        static int getLastId() {
+            return mLastId;
+        }
+    }
+
     @Test
     public void spyStatic() throws Exception {
         ContentResolver resolver = InstrumentationRegistry.getTargetContext().getContentResolver();
@@ -95,6 +107,23 @@ public class MockStatic {
 
             // Make sure non-mocked methods work as before
             assertEquals(deviceName, Settings.Global.getString(resolver, DEVICE_NAME));
+        } finally {
+            session.finishMocking();
+        }
+    }
+
+    @Test
+    public void spyStaticOnObjectWithNoDefaultConstructor() throws Exception {
+        new NoDefaultConstructorClass(23);
+
+        MockitoSession session = mockitoSession().spyStatic(NoDefaultConstructorClass.class)
+                .startMocking();
+        try {
+            // Starting the spying hasn't change the static state of the class.
+            assertEquals(23, NoDefaultConstructorClass.getLastId());
+
+            when(NoDefaultConstructorClass.getLastId()).thenReturn(42);
+            assertEquals(42, NoDefaultConstructorClass.getLastId());
         } finally {
             session.finishMocking();
         }

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticMockitoSessionBuilder.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticMockitoSessionBuilder.java
@@ -26,6 +26,9 @@ import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.withSettings;
+
 /**
  * Same as {@link MockitoSessionBuilder} but adds the ability to stub static methods
  * calls via {@link #mockStatic(Class)}, {@link #mockStatic(Class, Answer)}, and
@@ -97,7 +100,8 @@ public class StaticMockitoSessionBuilder implements MockitoSessionBuilder {
      */
     @UnstableApi
     public <T> StaticMockitoSessionBuilder spyStatic(Class<T> clazz) {
-        staticMockings.add(new StaticMocking<>(clazz, () -> Mockito.spy(clazz)));
+        staticMockings.add(new StaticMocking<>(clazz, () -> Mockito.mock(clazz, withSettings()
+                .defaultAnswer(CALLS_REAL_METHODS))));
         return this;
     }
 


### PR DESCRIPTION
When calling Mockito.spy(Class c) Mockito tries to create an object of 'c' using the 0-args constructor and fails if this is not possible.

For static spying the created object is just a marker and is not used for anything, hence there is no need to create a correctly constructed objects. Hence creating a mock is enough. We still have to call the real-methods by default as this settings also applies to static methods.

I added a test that previously failed at spyStatic()