### PR TITLE
Allow for AccessFlags.ACC_SYNTHETIC.

### DIFF
--- a/dexmaker/src/main/java/com/android/dx/DexMaker.java
+++ b/dexmaker/src/main/java/com/android/dx/DexMaker.java
@@ -232,7 +232,8 @@ public final class DexMaker {
     public void declare(TypeId<?> type, String sourceFile, int flags,
             TypeId<?> supertype, TypeId<?>... interfaces) {
         TypeDeclaration declaration = getTypeDeclaration(type);
-        int supportedFlags = Modifier.PUBLIC | Modifier.FINAL | Modifier.ABSTRACT;
+        int supportedFlags = Modifier.PUBLIC | Modifier.FINAL | Modifier.ABSTRACT
+                | AccessFlags.ACC_SYNTHETIC;
         if ((flags & ~supportedFlags) != 0) {
             throw new IllegalArgumentException("Unexpected flag: "
                     + Integer.toHexString(flags));
@@ -265,7 +266,8 @@ public final class DexMaker {
         }
 
         int supportedFlags = Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED
-                | Modifier.STATIC | Modifier.FINAL | Modifier.SYNCHRONIZED;
+                | Modifier.STATIC | Modifier.FINAL | Modifier.SYNCHRONIZED
+                | AccessFlags.ACC_SYNTHETIC;
         if ((flags & ~supportedFlags) != 0) {
             throw new IllegalArgumentException("Unexpected flag: "
                     + Integer.toHexString(flags));


### PR DESCRIPTION
AFAICT, there should be no reason this shouldn't be supported. It's
just adding an extra flag to the Method. Given that DexMaker is used
to generate code, it makes sense that we're going to frequently
generate synthetic methods.

I didn't really test this, except for validating that the constants in
Modifier, matches the constants in AccessFlags.