### PR TITLE
Adding support for BRIDGE methods and SYNTHETIC fields

### DIFF
--- a/dexmaker/src/main/java/com/android/dx/DexMaker.java
+++ b/dexmaker/src/main/java/com/android/dx/DexMaker.java
@@ -267,7 +267,7 @@ public final class DexMaker {
 
         int supportedFlags = Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED
                 | Modifier.STATIC | Modifier.FINAL | Modifier.SYNCHRONIZED
-                | AccessFlags.ACC_SYNTHETIC;
+                | AccessFlags.ACC_SYNTHETIC | AccessFlags.ACC_BRIDGE;
         if ((flags & ~supportedFlags) != 0) {
             throw new IllegalArgumentException("Unexpected flag: "
                     + Integer.toHexString(flags));
@@ -305,7 +305,8 @@ public final class DexMaker {
         }
 
         int supportedFlags = Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED
-                | Modifier.STATIC | Modifier.FINAL | Modifier.VOLATILE | Modifier.TRANSIENT;
+                | Modifier.STATIC | Modifier.FINAL | Modifier.VOLATILE | Modifier.TRANSIENT
+                | AccessFlags.ACC_SYNTHETIC;
         if ((flags & ~supportedFlags) != 0) {
             throw new IllegalArgumentException("Unexpected flag: "
                     + Integer.toHexString(flags));


### PR DESCRIPTION
Bridge methods are created by the java compiler, I need to generate them when copying existing classes (for github.com/tdrhq/eyepatch). Also, while I'm at it, in my previous pull request I forgot to add support for ACC_SYNTHETIC to fields too.