### PR TITLE
Fixes #124: Avoid duplication of names of proxy classes based on the same class

### DIFF
--- a/dexmaker-tests/src/androidTest/java/com/android/dx/DexMakerTest.java
+++ b/dexmaker-tests/src/androidTest/java/com/android/dx/DexMakerTest.java
@@ -2142,6 +2142,30 @@ public final class DexMakerTest {
         }
     }
 
+    public interface BlankInterfaceA {}
+
+    public interface BlankInterfaceB {}
+
+    @Test
+    public void testCaching_DifferentInterfaces() throws Exception {
+        int origSize = getDataDirectory().listFiles().length;
+
+        // Create new dexmaker generator with BlankInterfaceA.
+        dexMaker = new DexMaker();
+        TypeId interfaceA = TypeId.get(BlankInterfaceA.class);
+        dexMaker.declare(GENERATED, "Generated.java", PUBLIC, TypeId.OBJECT, interfaceA);
+        generateAndLoad();
+        int numFiles = getDataDirectory().listFiles().length;
+        assertTrue(origSize < numFiles);
+
+        // Create new dexmaker generator with BlankInterfaceB.
+        dexMaker = new DexMaker();
+        TypeId interfaceB = TypeId.get(BlankInterfaceB.class);
+        dexMaker.declare(GENERATED, "Generated.java", PUBLIC, TypeId.OBJECT, interfaceB);
+        generateAndLoad();
+        assertTrue(numFiles < getDataDirectory().listFiles().length);
+    }
+
     @Test
     public void testCaching_Constructors() throws Exception {
         int origSize = getDataDirectory().listFiles().length;

--- a/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
+++ b/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
@@ -33,11 +33,8 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -1253,24 +1250,5 @@ public class ProxyBuilderTest {
         Class<?> c2 = ProxyBuilder.forClass(SimpleClass.class)
                 .implementing(Callable.class).withSharedClassLoader().buildProxyClass();
         assertNotSame(c1, c2);
-    }
-
-    @Test
-    public void testImplementingDifferentInterfacesWithDexMakerCaching() throws Exception {
-        proxyFor(SimpleClass.class).implementing(Runnable.class).buildProxyClass();
-        assertEquals(1, getGeneratedProxyClasses().size());
-        assertEquals(2, versionedDxDir.listFiles().length);
-
-        proxyFor(SimpleClass.class).implementing(Callable.class).buildProxyClass();
-        assertEquals(2, getGeneratedProxyClasses().size());
-        assertEquals(3, versionedDxDir.listFiles().length);
-
-        Map<?, ?> cacheCopy = new HashMap<>(getGeneratedProxyClasses());
-        Set<?> generatedFiles = new HashSet<>(Arrays.asList(versionedDxDir.listFiles()));
-
-        proxyFor(SimpleClass.class).implementing(Runnable.class).buildProxyClass();
-        proxyFor(SimpleClass.class).implementing(Callable.class).buildProxyClass();
-        assertEquals(cacheCopy, getGeneratedProxyClasses());
-        assertEquals(generatedFiles, new HashSet<>(Arrays.asList(versionedDxDir.listFiles())));
     }
 }

--- a/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
+++ b/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
@@ -1251,4 +1251,15 @@ public class ProxyBuilderTest {
                 .implementing(Callable.class).withSharedClassLoader().buildProxyClass();
         assertNotSame(c1, c2);
     }
+
+    @Test
+    public void testInterfaceOrder() throws Exception {
+        Class<?> c1 = proxyFor(SimpleClass.class)
+                .implementing(Runnable.class, Callable.class).buildProxyClass();
+        assertEquals(new Class[]{Runnable.class, Callable.class}, c1.getInterfaces());
+
+        Class<?> c2 = proxyFor(SimpleClass.class)
+                .implementing(Callable.class, Runnable.class).buildProxyClass();
+        assertEquals(new Class[]{Callable.class, Runnable.class}, c2.getInterfaces());
+    }
 }

--- a/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
+++ b/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
@@ -46,6 +46,7 @@ import static junit.framework.Assert.assertSame;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assume.assumeTrue;
 
 public class ProxyBuilderTest {
@@ -1238,5 +1239,16 @@ public class ProxyBuilderTest {
         assertEquals("D", proxy.returnD());
         assertEquals("fake E", proxy.returnE());
 
+    }
+
+    @Test
+    public void testImplementingDifferentInterfacesWithSharedClassLoader() throws IOException {
+        assumeTrue(Build.VERSION.SDK_INT >= 24);
+
+        Class<?> c1 = ProxyBuilder.forClass(SimpleClass.class)
+                .implementing(Runnable.class).withSharedClassLoader().buildProxyClass();
+        Class<?> c2 = ProxyBuilder.forClass(SimpleClass.class)
+                .implementing(Callable.class).withSharedClassLoader().buildProxyClass();
+        assertNotSame(c1, c2);
     }
 }

--- a/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
+++ b/dexmaker-tests/src/androidTest/java/com/android/dx/stock/ProxyBuilderTest.java
@@ -33,8 +33,11 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -1250,5 +1253,24 @@ public class ProxyBuilderTest {
         Class<?> c2 = ProxyBuilder.forClass(SimpleClass.class)
                 .implementing(Callable.class).withSharedClassLoader().buildProxyClass();
         assertNotSame(c1, c2);
+    }
+
+    @Test
+    public void testImplementingDifferentInterfacesWithDexMakerCaching() throws Exception {
+        proxyFor(SimpleClass.class).implementing(Runnable.class).buildProxyClass();
+        assertEquals(1, getGeneratedProxyClasses().size());
+        assertEquals(2, versionedDxDir.listFiles().length);
+
+        proxyFor(SimpleClass.class).implementing(Callable.class).buildProxyClass();
+        assertEquals(2, getGeneratedProxyClasses().size());
+        assertEquals(3, versionedDxDir.listFiles().length);
+
+        Map<?, ?> cacheCopy = new HashMap<>(getGeneratedProxyClasses());
+        Set<?> generatedFiles = new HashSet<>(Arrays.asList(versionedDxDir.listFiles()));
+
+        proxyFor(SimpleClass.class).implementing(Runnable.class).buildProxyClass();
+        proxyFor(SimpleClass.class).implementing(Callable.class).buildProxyClass();
+        assertEquals(cacheCopy, getGeneratedProxyClasses());
+        assertEquals(generatedFiles, new HashSet<>(Arrays.asList(versionedDxDir.listFiles())));
     }
 }

--- a/dexmaker/src/main/java/com/android/dx/DexMaker.java
+++ b/dexmaker/src/main/java/com/android/dx/DexMaker.java
@@ -356,7 +356,8 @@ public final class DexMaker {
             TypeDeclaration decl = getTypeDeclaration(typeId);
             Set<MethodId> methodSet = decl.methods.keySet();
             if (decl.supertype != null) {
-                checksums[i++] = 31 * decl.supertype.hashCode() + methodSet.hashCode();
+                int sum = 31 * decl.supertype.hashCode() + decl.interfaces.hashCode();
+                checksums[i++] = 31 * sum + methodSet.hashCode();
             }
         }
         Arrays.sort(checksums);

--- a/dexmaker/src/main/java/com/android/dx/stock/ProxyBuilder.java
+++ b/dexmaker/src/main/java/com/android/dx/stock/ProxyBuilder.java
@@ -281,7 +281,7 @@ public final class ProxyBuilder<T> {
 
         // the cache missed; generate the class
         DexMaker dexMaker = new DexMaker();
-        String generatedName = getMethodNameForProxyOf(baseClass);
+        String generatedName = getMethodNameForProxyOf(baseClass, interfaces);
         TypeId<? extends T> generatedType = TypeId.get("L" + generatedName + ";");
         TypeId<T> superType = TypeId.get(baseClass);
         generateConstructorsAndFields(dexMaker, generatedType, superType, baseClass);
@@ -813,8 +813,9 @@ public final class ProxyBuilder<T> {
         }
     }
 
-    private static <T> String getMethodNameForProxyOf(Class<T> clazz) {
-        return clazz.getName().replace(".", "/") + "_Proxy";
+    private static <T> String getMethodNameForProxyOf(Class<T> clazz, Set<Class<?>> interfaces) {
+        String interfacesHash = Integer.toHexString(interfaces.hashCode());
+        return clazz.getName().replace(".", "/") + "_" + interfacesHash + "_Proxy";
     }
 
     private static TypeId<?>[] classArrayToTypeArray(Class<?>[] input) {

--- a/dexmaker/src/main/java/com/android/dx/stock/ProxyBuilder.java
+++ b/dexmaker/src/main/java/com/android/dx/stock/ProxyBuilder.java
@@ -34,11 +34,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -139,7 +141,7 @@ public final class ProxyBuilder<T> {
     private File dexCache;
     private Class<?>[] constructorArgTypes = new Class[0];
     private Object[] constructorArgValues = new Object[0];
-    private Set<Class<?>> interfaces = new HashSet<>();
+    private List<Class<?>> interfaces = new ArrayList<>();
     private Method[] methods;
     private boolean sharedClassLoader;
     private boolean markTrusted;
@@ -179,11 +181,14 @@ public final class ProxyBuilder<T> {
     }
 
     public ProxyBuilder<T> implementing(Class<?>... interfaces) {
+        List<Class<?>> list = this.interfaces;
         for (Class<?> i : interfaces) {
             if (!i.isInterface()) {
                 throw new IllegalArgumentException("Not an interface: " + i.getName());
             }
-            this.interfaces.add(i);
+            if (!list.contains(i)) {
+                list.add(i);
+            }
         }
         return this;
     }
@@ -811,7 +816,7 @@ public final class ProxyBuilder<T> {
         }
     }
 
-    private static <T> String getMethodNameForProxyOf(Class<T> clazz, Set<Class<?>> interfaces) {
+    private static <T> String getMethodNameForProxyOf(Class<T> clazz, List<Class<?>> interfaces) {
         String interfacesHash = Integer.toHexString(interfaces.hashCode());
         return clazz.getName().replace(".", "/") + "_" + interfacesHash + "_Proxy";
     }
@@ -944,7 +949,7 @@ public final class ProxyBuilder<T> {
     private static class ProxiedClass<U> {
         final Class<U> clazz;
 
-        final Set<?> interfaces;
+        final List<Class<?>> interfaces;
 
         /**
          * Class loader requested when the proxy class was generated. This might not be the
@@ -978,10 +983,10 @@ public final class ProxyBuilder<T> {
                     + (sharedClassLoader ? 1 : 0); 
         }
 
-        private ProxiedClass(Class<U> clazz, Set<?> interfaces, ClassLoader requestedClassloader,
-                             boolean sharedClassLoader) {
+        private ProxiedClass(Class<U> clazz, List<Class<?>> interfaces,
+                             ClassLoader requestedClassloader, boolean sharedClassLoader) {
             this.clazz = clazz;
-            this.interfaces = interfaces;
+            this.interfaces = new ArrayList<>(interfaces);
             this.requestedClassloader = requestedClassloader;
             this.sharedClassLoader = sharedClassLoader;
         }


### PR DESCRIPTION
Fixes #124
- Add the hash of interfaces to the proxy class name
- Include interfaces in the proxy class cache key