### PR TITLE
Restrict InspectClass to current thread.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 
 before_install:
   - mkdir $ANDROID_HOME/licenses
-  - echo -ne "\n8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e" >> $ANDROID_HOME/licenses/android-sdk-license
+  - echo -ne "\n8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e\n24333f8a63b6825ea9c5514f83c2829b004d1fee" >> $ANDROID_HOME/licenses/android-sdk-license
   - echo -ne "\n79120722343a6f314e0719f863036c702b0e6b2a\n84831b9409646a918e30573bab4c9c91346d8abd" >> $ANDROID_HOME/licenses/android-sdk-preview-license
   - $ANDROID_HOME/tools/bin/sdkmanager "ndk-bundle"
   - $ANDROID_HOME/tools/bin/sdkmanager "cmake;3.6.4111459"

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
@@ -152,7 +152,7 @@ class StaticMockMethodAdvice {
         return subclasses;
     }
 
-    private synchronized static native String nativeGetCalledClassName();
+    private synchronized static native String nativeGetCalledClassName(Thread currentThread);
 
     private Class<?> getClassMethodWasCalledOn(MethodDesc methodDesc) throws ClassNotFoundException,
             NoSuchMethodException {
@@ -183,7 +183,7 @@ class StaticMockMethodAdvice {
                 return null;
             }
 
-            String calledClassName = nativeGetCalledClassName();
+            String calledClassName = nativeGetCalledClassName(Thread.currentThread());
             return Class.forName(calledClassName);
         }
     }

--- a/dexmaker-mockito-inline-extended/src/main/jni/staticjvmtiagent/agent.cc
+++ b/dexmaker-mockito-inline-extended/src/main/jni/staticjvmtiagent/agent.cc
@@ -747,7 +747,9 @@ namespace com_android_dx_mockito_inline {
 
     extern "C" JNIEXPORT jstring JNICALL
     Java_com_android_dx_mockito_inline_StaticMockMethodAdvice_nativeGetCalledClassName(JNIEnv* env,
-                                                                                     jclass klass) {
+                                                                            jclass klass,
+                                                                            jthread currentThread) {
+
         JavaVM *vm;
         jint jvmError = env->GetJavaVM(&vm);
         if (jvmError != JNI_OK) {
@@ -804,7 +806,7 @@ namespace com_android_dx_mockito_inline {
         GOTO_ON_ERROR(unregister_env_and_exit);
 
         error = jvmtiEnv->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
-                                                   nullptr);
+                                                   currentThread);
         GOTO_ON_ERROR(unset_cb_and_exit);
 
         frameToInspect = &frameInfo[callingFrameNum];
@@ -813,7 +815,7 @@ namespace com_android_dx_mockito_inline {
 
         disable_hook_and_exit:
         jvmtiEnv->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
-                                           nullptr);
+                                           currentThread);
 
         unset_cb_and_exit:
         memset(&cb, 0, sizeof(cb));


### PR DESCRIPTION
If there are other threads asking for class restransformation
InspectClass may be called during the transient period of time when the
callback is enabled. More importantly InspectClass could be called after
jvmti env is disposed, which would lead to native crashes.

This should fix issue #134.