### PR TITLE
Update to Mockito 2.25.0 and implement InlineMockMaker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ For Mockito support, download the latest .jar via Maven:
     <dependency>
       <groupId>com.linkedin.dexmaker</groupId>
       <artifactId>dexmaker-mockito</artifactId>
-      <version>2.21.0</version>
+      <version>2.25.0</version>
       <type>pom</type>
     </dependency>
 ```
 
 or Gradle:
 ```
-    androidTestCompile 'com.linkedin.dexmaker:dexmaker-mockito:2.21.0'
+    androidTestCompile 'com.linkedin.dexmaker:dexmaker-mockito:2.25.0'
 ```
 
 _Note: The dependency on Mockito will be transitively included, so there's no need to specify both Mockito AND dexmaker-mockito_

--- a/dexmaker-mockito-inline-extended-tests/build.gradle
+++ b/dexmaker-mockito-inline-extended-tests/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     implementation 'com.android.support.test:runner:1.0.2'
     implementation 'com.android.support.test:rules:1.0.2'
 
-    api 'org.mockito:mockito-core:2.21.0', { exclude group: 'net.bytebuddy' }
+    api 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -119,5 +119,5 @@ repositories {
 dependencies {
     implementation project(':dexmaker-mockito-inline')
 
-    implementation 'org.mockito:mockito-core:2.21.0', { exclude group: 'net.bytebuddy' }
+    implementation 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -50,5 +50,5 @@ dependencies {
 
     implementation 'junit:junit:4.12'
     implementation 'com.android.support.test:runner:1.0.2'
-    api 'org.mockito:mockito-core:2.21.0', { exclude group: 'net.bytebuddy' }
+    api 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline-tests/src/main/java/com/android/dx/mockito/inline/tests/MemoryLeaks.java
+++ b/dexmaker-mockito-inline-tests/src/main/java/com/android/dx/mockito/inline/tests/MemoryLeaks.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.tests;
+
+import static org.mockito.Mockito.framework;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import android.support.test.runner.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class MemoryLeaks {
+    private static final int ARRAY_LENGTH = 1 << 20;  // 4 MB
+
+    @Test
+    public void callMethodWithMocksCycalically() {
+        for (int i = 0; i < 100; ++i) {
+            final A a = mock(A.class);
+            a.largeArray = new int[ARRAY_LENGTH];
+            final B b = mock(B.class);
+
+            a.accept(b);
+            b.accept(a);
+
+            framework().clearInlineMocks();
+        }
+    }
+
+    @Test
+    public void spyRefersToItself() {
+        for (int i = 0; i < 100; ++i) {
+            final DeepRefSelfClass instance = spy(new DeepRefSelfClass());
+            instance.refInstance(instance);
+
+            framework().clearInlineMocks();
+        }
+    }
+
+    private static class A {
+        private int[] largeArray;
+
+        void accept(B b) {}
+    }
+
+    private static class B {
+        void accept(A a) {}
+    }
+
+    private static class DeepRefSelfClass {
+        private final DeepRefSelfClass[] array = new DeepRefSelfClass[1];
+
+        private final int[] largeArray = new int[ARRAY_LENGTH];
+
+        private void refInstance(DeepRefSelfClass instance) {
+            array[0] = instance;
+        }
+    }
+}

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -113,6 +113,6 @@ repositories {
 dependencies {
     implementation project(':dexmaker')
 
-    implementation 'org.mockito:mockito-core:2.21.0', { exclude group: 'net.bytebuddy' }
+    implementation 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
 }
 

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InlineDexmakerMockMaker.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InlineDexmakerMockMaker.java
@@ -29,6 +29,7 @@ import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.reflection.LenientCopyTool;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
+import org.mockito.plugins.InlineMockMaker;
 import org.mockito.plugins.InstantiatorProvider2;
 import org.mockito.plugins.MockMaker;
 
@@ -54,7 +55,7 @@ import java.util.Set;
  * <p>This is done by transforming the byte code of the classes to add method entry hooks.
  */
 
-public final class InlineDexmakerMockMaker implements MockMaker {
+public final class InlineDexmakerMockMaker implements InlineMockMaker {
     private static final String DISPATCHER_CLASS_NAME =
             "com.android.dx.mockito.inline.MockMethodDispatcher";
     private static final String DISPATCHER_JAR = "dispatcher.jar";
@@ -343,6 +344,16 @@ public final class InlineDexmakerMockMaker implements MockMaker {
                 return "not handled type";
             }
         };
+    }
+
+    @Override
+    public void clearMock(Object mock) {
+        mocks.remove(mock);
+    }
+
+    @Override
+    public void clearAllMocks() {
+        mocks.clear();
     }
 
     @Override

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
@@ -20,6 +20,7 @@ import android.util.Log;
 
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
+import org.mockito.plugins.InlineMockMaker;
 import org.mockito.plugins.MockMaker;
 
 import java.lang.reflect.InvocationTargetException;
@@ -28,7 +29,7 @@ import java.util.ArrayList;
 /**
  * Multiplexes multiple mock makers
  */
-public final class MockMakerMultiplexer implements MockMaker {
+public final class MockMakerMultiplexer implements InlineMockMaker {
     private static final String LOG_TAG = MockMakerMultiplexer.class.getSimpleName();
     private final static MockMaker[] MOCK_MAKERS;
 
@@ -102,5 +103,29 @@ public final class MockMakerMultiplexer implements MockMaker {
         }
 
         return null;
+    }
+
+    @Override
+    public void clearMock(Object mock) {
+        for (MockMaker mockMaker : MOCK_MAKERS) {
+            if (!(mockMaker instanceof InlineMockMaker)) {
+                continue;
+            }
+
+            InlineMockMaker inlineMockMaker = (InlineMockMaker) mockMaker;
+            inlineMockMaker.clearMock(mock);
+        }
+    }
+
+    @Override
+    public void clearAllMocks() {
+        for (MockMaker mockMaker : MOCK_MAKERS) {
+            if (!(mockMaker instanceof InlineMockMaker)) {
+                continue;
+            }
+
+            InlineMockMaker inlineMockMaker = (InlineMockMaker) mockMaker;
+            inlineMockMaker.clearAllMocks();
+        }
     }
 }

--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -42,5 +42,5 @@ dependencies {
 
     implementation 'com.android.support.test:runner:0.5'
     implementation 'junit:junit:4.12'
-    api 'org.mockito:mockito-core:2.21.0', { exclude group: 'net.bytebuddy' }
+    api 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -26,5 +26,5 @@ repositories {
 dependencies {
     implementation project(':dexmaker')
 
-    implementation 'org.mockito:mockito-core:2.21.0', { exclude group: 'net.bytebuddy' }
+    implementation 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ org.gradle.configureondemand=false
 # org.gradle.parallel=true
 
 GROUP_ID=com.linkedin.dexmaker
-VERSION_NAME=2.21.1-SNAPSHOT
+VERSION_NAME=2.25.0-SNAPSHOT


### PR DESCRIPTION
In certain specific, rare cases inline mocking causes memory leaks.
Mockito introduced a new API to explicitly clear mock state in version
2.25.0. To make that work we need to implement the new InlineMockMaker
interface, hence I make this pull request.

This fixes #137.