### PR TITLE
Enabled local testing of Maven artifacts

### DIFF
--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -107,6 +107,13 @@ publishing {
                     }
                 }
             }
+
+            //Useful for inspecting maven artifacts in 'build/repo' after running './gradlew publish'
+            repositories {
+                maven {
+                    url = "$rootProject.buildDir/repo"
+                }
+            }
         }
     }
 }

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -101,6 +101,13 @@ publishing {
                     }
                 }
             }
+
+            //Useful for inspecting maven artifacts in 'build/repo' after running './gradlew publish'
+            repositories {
+                maven {
+                    url = "$rootProject.buildDir/repo"
+                }
+            }
         }
     }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -54,6 +54,13 @@ publishing {
                     }
                 }.each { it.scope*.value = 'compile'}
             }
+                        
+            //Useful for inspecting maven artifacts in 'build/repo' after running './gradlew publish'
+            repositories {
+                maven {
+                    url = "$rootProject.buildDir/repo"
+                }
+            }
         }
         ivyJava(IvyPublication) {
             from components.java


### PR DESCRIPTION
Running './gradlew publish' will create local maven repo with artifacts and metadata, under "build/repo" directory.

The change is safe and does not interefe with the current way you publish dexmaker. It's similar to https://github.com/linkedin/shaky-android/pull/31/files

There's a little bit of duplication but let's be pragmatic - it's passable. Wrapping up this duplication would add more complexity than it's worth.