### PR TITLE
Switch to BufferedOutputStream in DexMaker.java

### DIFF
--- a/dexmaker/src/main/java/com/android/dx/DexMaker.java
+++ b/dexmaker/src/main/java/com/android/dx/DexMaker.java
@@ -32,6 +32,7 @@ import com.android.dx.rop.cst.CstString;
 import com.android.dx.rop.cst.CstType;
 import com.android.dx.rop.type.StdTypeList;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -528,13 +529,22 @@ public final class DexMaker {
          * TODO: load the dex from memory where supported.
          */
         result.createNewFile();
-        JarOutputStream jarOut = new JarOutputStream(new FileOutputStream(result));
-        JarEntry entry = new JarEntry(DexFormat.DEX_IN_JAR_NAME);
-        entry.setSize(dex.length);
-        jarOut.putNextEntry(entry);
-        jarOut.write(dex);
-        jarOut.closeEntry();
-        jarOut.close();
+        
+        JarOutputStream jarOut =
+            new JarOutputStream(new BufferedOutputStream(new FileOutputStream(result)));
+        try {
+            JarEntry entry = new JarEntry(DexFormat.DEX_IN_JAR_NAME);
+            entry.setSize(dex.length);
+            jarOut.putNextEntry(entry);
+            try {
+                jarOut.write(dex);
+            } finally {
+                jarOut.closeEntry();
+            }
+        } finally {
+            jarOut.close();
+        }
+        
         return generateClassLoader(result, dexCache, parent);
     }
 


### PR DESCRIPTION
Android's StrictMode will throw exceptions and crash because this file uses unbuffered io. This switches to BufferedOutputStream and adds try/finally blocks to ensure subsequent errors are prevented should something fail.

This can be seen using mockito's mock() and spy() functions. 