### PR TITLE
Allow ProxyBuilder to call hidden APIs

### DIFF
--- a/dexmaker-mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
+++ b/dexmaker-mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
@@ -77,6 +77,17 @@ public final class DexmakerMockMaker implements MockMaker, StackTraceCleanerProv
                 System.err.println("Cannot allow LenientCopyTool to copy spies of blacklisted "
                         + "fields. This might break spying on system classes.");
             }
+
+            // The ProxyBuilder class needs to be able to see hidden methods in order to proxy
+            // them correctly. If it cannot see blacklisted methods, then other system classes
+            // which call hidden methods on the mock will call through to the real method rather
+            // than the proxy, which may cause crashes or other unexpected behavior.
+            try {
+                allowHiddenApiReflectionFromMethod.invoke(null, ProxyBuilder.class);
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                System.err.println("Cannot allow ProxyBuilder to proxy blacklisted "
+                        + "methods. This might break mocking on system classes.");
+            }
         }
     }
 


### PR DESCRIPTION
Consider the following scenario:
- A test creates a mock of class A, which contains a
  blacklisted API
- ProxyBuilder cannot see the blacklisted method, so
  it does not create a proxy for that method (calling
  getDeclaredMethods() on the class omits the blacklisted
  methods).
- The test now passes the mock of class A to another
  system class, B.
- B contains code that calls the blacklisted method,
  and consequently calls through to the real implementation
  of that blacklisted method.
- The real implementation of the blacklisted method
  accesses some field which has not been initialized and
  therefore crashes.

Whitelisting ProxyBuilder to be able to call hidden
APIs will allow it to properly create proxies for those
methods and prevent this type of crash.