### PR TITLE
Update mockito to 2.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.25.2-SNAPSHOT
 - Support generating locals that reference generated class types - [#151](https://github.com/linkedin/dexmaker/pull/151)
+- Update Mockito to 2.28.2 - [#153](https://github.com/linkedin/dexmaker/pull/153)
 
 ## Version 2.25.1 (2019-11-21)
 - Add support for abstract and native methods generation - [#144](https://github.com/linkedin/dexmaker/pull/144)

--- a/dexmaker-mockito-inline-extended-tests/build.gradle
+++ b/dexmaker-mockito-inline-extended-tests/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     implementation 'androidx.test:runner:1.1.1'
     implementation 'androidx.test:rules:1.1.1'
 
-    api 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
+    api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -126,5 +126,5 @@ repositories {
 dependencies {
     implementation project(':dexmaker-mockito-inline')
 
-    implementation 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
+    implementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -50,5 +50,5 @@ dependencies {
 
     implementation 'junit:junit:4.12'
     implementation 'androidx.test:runner:1.1.1'
-    api 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
+    api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -120,6 +120,6 @@ repositories {
 dependencies {
     implementation project(':dexmaker')
 
-    implementation 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
+    implementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }
 

--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -42,5 +42,5 @@ dependencies {
 
     implementation 'androidx.test:runner:1.1.1'
     implementation 'junit:junit:4.12'
-    api 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
+    api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -26,5 +26,5 @@ repositories {
 dependencies {
     implementation project(':dexmaker')
 
-    implementation 'org.mockito:mockito-core:2.25.0', { exclude group: 'net.bytebuddy' }
+    implementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }


### PR DESCRIPTION
We have encountered exceptions when initializing the mocker maker
plugin when using mockito-inline in tandem with
dexmaker-mockito-inline at 2.25.0. This pull request bumped to the
latest mockito2 version to pick up the update of bytebuddy.

Exception
https://gist.github.com/chao2zhang/ee1160612491376daf63fd5a60e1757d