### PR TITLE
Fix build failures and bump to AGP 3.6 and Gradle 5.6.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ local.properties
 *.ipr
 *.iws
 *.svn
+.cxx/

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.7.3"
+        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.15.1"
     }
 }
 
@@ -45,5 +45,10 @@ artifactory {
 }
 
 task distributeBuild(type: DistributeTask) {
-    dependsOn ':artifactoryPublish', 'dexmaker:artifactoryPublish', 'dexmaker-mockito:artifactoryPublish', 'dexmaker-mockito-inline:artifactoryPublish', 'dexmaker-mockito-inline-extended:artifactoryPublish'
+    dependsOn ':artifactoryPublish',
+            'dexmaker:artifactoryPublish',
+            'dexmaker-mockito:artifactoryPublish',
+            'dexmaker-mockito-inline:artifactoryPublish',
+            'dexmaker-mockito-inline-extended:artifactoryPublish'
 }
+

--- a/dexmaker-mockito-inline-extended-tests/build.gradle
+++ b/dexmaker-mockito-inline-extended-tests/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
-    }
-}
-
-apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.library'
 
 android {

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -1,21 +1,11 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
-    }
+plugins {
+    id("net.ltgt.errorprone") version "0.8"
 }
-
-apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.library'
-apply plugin: 'maven-publish'
-apply plugin: 'ivy-publish'
-apply plugin: 'com.jfrog.artifactory'
+apply from: "$rootDir/gradle/publishing_aar.gradle"
 
 version = VERSION_NAME
+description = 'Extension of the Mockito Inline API to allow mocking static methods on the Android Dalvik VM'
 
 android {
     compileSdkVersion 28
@@ -46,81 +36,13 @@ android {
     }
 }
 
-tasks.withType(JavaCompile) {
-    options.compilerArgs += ["-Xep:StringSplitter:OFF"]
-}
-
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-publishing {
-    publications {
-        ivyLib(IvyPublication) {
-            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.implementation.getAllDependencies())
-            artifact sourcesJar
-            artifact javadocJar
-        }
-
-        lib(MavenPublication) {
-            from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.implementation.getAllDependencies())
-
-            artifact sourcesJar
-            artifact javadocJar
-
-            pom.withXml {
-                asNode().children().last() + {
-                    resolveStrategy = Closure.DELEGATE_FIRST
-                    description = 'Extension of the Mockito Inline API to allow mocking static methods on the Android Dalvik VM'
-                    url 'https://github.com/linkedin/dexmaker'
-                    scm {
-                        url 'https://github.com/linkedin/dexmaker'
-                        connection 'scm:git:git://github.com/linkedin/dexmaker.git'
-                        developerConnection 'https://github.com/linkedin/dexmaker.git'
-                    }
-                    licenses {
-                        license {
-                            name 'The Apache Software License, Version 2.0'
-                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                            distribution 'repo'
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id 'com.linkedin'
-                            name 'LinkedIn Corp'
-                            email ''
-                        }
-                    }
-                }
-            }
-
-            //Useful for inspecting maven artifacts in 'build/repo' after running './gradlew publish'
-            repositories {
-                maven {
-                    url = "$rootProject.buildDir/repo"
-                }
-            }
-        }
-    }
-}
-
 repositories {
-    jcenter()
     google()
+    jcenter()
+}
+
+tasks.withType(JavaCompile) {
+    options.errorprone.errorproneArgs.add("-Xep:StringSplitter:OFF")
 }
 
 dependencies {

--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
-    }
-}
-
-apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.library'
 
 android {

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -1,21 +1,11 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
-    }
+plugins {
+    id("net.ltgt.errorprone") version "0.8"
 }
-
-apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.library'
-apply plugin: 'maven-publish'
-apply plugin: 'ivy-publish'
-apply plugin: 'com.jfrog.artifactory'
+apply from: "$rootDir/gradle/publishing_aar.gradle"
 
 version = VERSION_NAME
+description = 'Implementation of the Mockito Inline API for use on the Android Dalvik VM'
 
 android {
     compileSdkVersion 28
@@ -41,80 +31,13 @@ android {
     }
 }
 
-tasks.withType(JavaCompile) {
-    options.compilerArgs += ["-Xep:StringSplitter:OFF"]
-}
-
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-publishing {
-    publications {
-        ivyLib(IvyPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.implementation.getAllDependencies())
-          artifact sourcesJar
-          artifact javadocJar
-        }
-
-        lib(MavenPublication) {
-          from new org.gradle.api.internal.java.JavaLibrary(new org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact(project.getName(), 'aar', 'aar', null, new Date(), new File("$buildDir/outputs/aar/${project.getName()}-release.aar"), assemble), project.configurations.implementation.getAllDependencies())
-
-            artifact sourcesJar
-            artifact javadocJar
-
-            pom.withXml {
-                asNode().children().last() + {
-                    resolveStrategy = Closure.DELEGATE_FIRST
-                    description = 'Implementation of the Mockito Inline API for use on the Android Dalvik VM'
-                    url 'https://github.com/linkedin/dexmaker'
-                    scm {
-                        url 'https://github.com/linkedin/dexmaker'
-                        connection 'scm:git:git://github.com/linkedin/dexmaker.git'
-                        developerConnection 'https://github.com/linkedin/dexmaker.git'
-                    }
-                    licenses {
-                        license {
-                            name 'The Apache Software License, Version 2.0'
-                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                            distribution 'repo'
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id 'com.linkedin'
-                            name 'LinkedIn Corp'
-                            email ''
-                        }
-                    }
-                }
-            }
-
-            //Useful for inspecting maven artifacts in 'build/repo' after running './gradlew publish'
-            repositories {
-                maven {
-                    url = "$rootProject.buildDir/repo"
-                }
-            }
-        }
-    }
-}
-
 repositories {
-    jcenter()
     google()
+    jcenter()
+}
+
+tasks.withType(JavaCompile) {
+    options.errorprone.errorproneArgs.add("-Xep:StringSplitter:OFF")
 }
 
 dependencies {
@@ -122,4 +45,3 @@ dependencies {
 
     implementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }
-

--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
-    }
-}
-
-apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.library'
 
 android {

--- a/dexmaker-mockito-tests/src/main/java/com/android/dx/mockito/tests/BlacklistedApis.java
+++ b/dexmaker-mockito-tests/src/main/java/com/android/dx/mockito/tests/BlacklistedApis.java
@@ -115,7 +115,7 @@ public class BlacklistedApis {
         parent.measure(100, 100);
     }
 
-    @SuppressLint({"PrivateApi", "CheckReturnValue"})
+    @SuppressLint({"PrivateApi", "CheckReturnValue", "SoonBlockedPrivateApi"})
     @Test
     public void cannotCallBlackListedAfterSpying() {
         // Spying and mocking might change the View class's byte code
@@ -132,7 +132,7 @@ public class BlacklistedApis {
     }
 
     public static class CallBlackListedMethod {
-        @SuppressLint("PrivateApi")
+        @SuppressLint({"PrivateApi", "SoonBlockedPrivateApi"})
         boolean callingBlacklistedMethodCausesException() {
             // Settings.Global#isValidZenMode is a blacklisted method. Resolving it should fail
             try {
@@ -151,7 +151,7 @@ public class BlacklistedApis {
     }
 
     public static abstract class CallBlacklistedMethodAbstract {
-        @SuppressLint("PrivateApi")
+        @SuppressLint({"PrivateApi", "SoonBlockedPrivateApi"})
         public boolean callingBlacklistedMethodCausesException() {
             // Settings.Global#isValidZenMode is a blacklisted method. Resolving it should fail
             try {

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -1,15 +1,6 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
-    }
+plugins {
+    id("net.ltgt.errorprone") version "0.8"
 }
-
-apply plugin: "net.ltgt.errorprone"
 apply plugin: 'java'
 apply from: "$rootDir/gradle/publishing.gradle"
 
@@ -21,6 +12,10 @@ sourceCompatibility = '1.7'
 
 repositories {
     jcenter()
+}
+
+tasks.withType(JavaCompile) {
+    options.errorprone.errorproneArgs.add("-Xep:StringSplitter:OFF")
 }
 
 dependencies {

--- a/dexmaker-tests/build.gradle
+++ b/dexmaker-tests/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
-    }
-}
-
-apply plugin: "net.ltgt.errorprone"
 apply plugin: 'com.android.application'
 
 android {

--- a/dexmaker/build.gradle
+++ b/dexmaker/build.gradle
@@ -1,15 +1,6 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"
-    }
+plugins {
+    id("net.ltgt.errorprone") version "0.8"
 }
-
-apply plugin: "net.ltgt.errorprone"
 apply plugin: 'java'
 apply from: "$rootDir/gradle/publishing.gradle"
 
@@ -24,7 +15,7 @@ repositories {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs += ["-Xep:StringSplitter:OFF"]
+    options.errorprone.errorproneArgs.add("-Xep:StringSplitter:OFF")
 }
 
 dependencies {

--- a/dexmaker/src/main/java/com/android/dx/Code.java
+++ b/dexmaker/src/main/java/com/android/dx/Code.java
@@ -481,7 +481,7 @@ public final class Code {
 
     /**
      * Copies a class type in {@code target}. The benefit to using this method vs {@link Code#loadConstant(Local, Object)}
-     * is that the {@value} can itself be a generated type - {@link TypeId} allows for deferred referencing of class types.
+     * is that the {@code value} can itself be a generated type - {@link TypeId} allows for deferred referencing of class types.
      */
     public void loadDeferredClassConstant(Local<Class> target, TypeId value) {
         loadConstantInternal(target, value);

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,5 @@ org.gradle.configureondemand=false
 
 GROUP_ID=com.linkedin.dexmaker
 VERSION_NAME=2.25.2-SNAPSHOT
+
+android.useAndroidX=true

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -22,7 +22,7 @@ publishing {
 
             pom.withXml {
                 asNode().children().last() + {
-                    resolveStrategy = Closure.DELEGATE_FIRST
+                    resolveStrategy = DELEGATE_FIRST
                     description "${ -> description }"
                     url 'https://github.com/linkedin/dexmaker'
                     scm {

--- a/gradle/publishing_aar.gradle
+++ b/gradle/publishing_aar.gradle
@@ -1,0 +1,75 @@
+apply plugin: 'maven-publish'
+apply plugin: 'ivy-publish'
+apply plugin: 'com.jfrog.artifactory'
+
+tasks.register("sourcesJar", Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+tasks.register("javadoc", Javadoc) {
+    failOnError false
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+tasks.register("javadocJar", Jar) {
+    dependsOn javadoc
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+// Need afterEvaluate according to https://developer.android.com/studio/build/maven-publish-plugin
+afterEvaluate {
+    publishing {
+        publications {
+            ivyLib(IvyPublication) {
+                from components.release
+                artifact sourcesJar
+                artifact javadocJar
+            }
+
+            lib(MavenPublication) {
+                from components.release
+
+                artifact sourcesJar
+                artifact javadocJar
+
+                pom.withXml {
+                    asNode().children().last() + {
+                        resolveStrategy = DELEGATE_FIRST
+                        description "${ -> description }"
+                        url 'https://github.com/linkedin/dexmaker'
+                        scm {
+                            url 'https://github.com/linkedin/dexmaker'
+                            connection 'scm:git:git://github.com/linkedin/dexmaker.git'
+                            developerConnection 'https://github.com/linkedin/dexmaker.git'
+                        }
+                        licenses {
+                            license {
+                                name 'The Apache Software License, Version 2.0'
+                                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                                distribution 'repo'
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                id 'com.linkedin'
+                                name 'LinkedIn Corp'
+                                email ''
+                            }
+                        }
+                    }
+                }
+
+                //Useful for inspecting maven artifacts in 'build/repo' after running './gradlew publish'
+                repositories {
+                    maven {
+                        url = "$rootProject.buildDir/repo"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The build failure was likely due to the legacy errorprone gradle
plugin, which was more than 3 years ago.
https://plugins.gradle.org/plugin/net.ltgt.errorprone/0.0.13

I upgraded errorprone gradle plugin to a recent version,
and also bump the AGP 3.6 and Gradle 5.6.4 because the errorprone
version requires a minimum Gradle 5.2.
https://github.com/tbroyer/gradle-errorprone-plugin/releases/tag/v0.8

I also used the maven publish integration from AGP by using
components.release
https://developer.android.com/studio/build/maven-publish-plugin

I currently disabled `failOnError` on javadoc, as the compilation
configuration is not applied to javadoc's classpath.
Gradle 6 introduced the concept of resolvable and consumable,
so I would recommend we revisit it when we are on Gradle 6.

I tested locally by mavenPublishToLocal using a standalone sample
app with android instrumentation tests. The tests can compile
successfully with proper dependency.

There are some minor changes:
- Prompted by IDE that Closure.DELEGATE_FIRST can be inlined
- New lint warnings that are SoonBlockedPrivateAPI
- Some attempts to fix javadoc errors
- Removed errorprone in test modules