### PR TITLE
Change mockito dependency to api

### DIFF
--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -48,5 +48,5 @@ tasks.withType(JavaCompile) {
 dependencies {
     implementation project(':dexmaker-mockito-inline')
 
-    implementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
+    api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -43,5 +43,5 @@ tasks.withType(JavaCompile) {
 dependencies {
     implementation project(':dexmaker')
 
-    implementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
+    api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("net.ltgt.errorprone") version "0.8"
 }
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply from: "$rootDir/gradle/publishing.gradle"
 
 version = VERSION_NAME
@@ -21,5 +21,5 @@ tasks.withType(JavaCompile) {
 dependencies {
     implementation project(':dexmaker')
 
-    implementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
+    api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
 }


### PR DESCRIPTION
So that consumers do not need to declare mockito dependency
explicitly.

Resolves #166 