### PR TITLE
Fix build when using newer versions of java

### DIFF
--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("net.ltgt.errorprone") version "0.8"
+    id("net.ltgt.errorprone") version "1.3.0"
 }
 apply plugin: 'com.android.library'
 apply from: "$rootDir/gradle/publishing_aar.gradle"
@@ -36,10 +36,14 @@ android {
 }
 
 tasks.withType(JavaCompile) {
-    options.errorprone.errorproneArgs.add("-Xep:StringSplitter:OFF")
+    options.errorprone {
+        disable("StringSplitter")
+    }
 }
 
 dependencies {
+    errorprone "com.google.errorprone:error_prone_core:2.5.1"
+
     implementation project(':dexmaker-mockito-inline')
 
     api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -43,6 +43,7 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     errorprone "com.google.errorprone:error_prone_core:2.5.1"
+    errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
     implementation project(':dexmaker-mockito-inline')
 

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -38,6 +38,7 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     errorprone "com.google.errorprone:error_prone_core:2.5.1"
+    errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
     implementation project(':dexmaker')
 

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("net.ltgt.errorprone") version "0.8"
+    id("net.ltgt.errorprone") version "1.3.0"
 }
 apply plugin: 'com.android.library'
 apply from: "$rootDir/gradle/publishing_aar.gradle"
@@ -31,10 +31,14 @@ android {
 }
 
 tasks.withType(JavaCompile) {
-    options.errorprone.errorproneArgs.add("-Xep:StringSplitter:OFF")
+    options.errorprone {
+        disable("StringSplitter")
+    }
 }
 
 dependencies {
+    errorprone "com.google.errorprone:error_prone_core:2.5.1"
+
     implementation project(':dexmaker')
 
     api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -18,6 +18,7 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     errorprone "com.google.errorprone:error_prone_core:2.5.1"
+    errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
     implementation project(':dexmaker')
 

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("net.ltgt.errorprone") version "0.8"
+    id("net.ltgt.errorprone") version "1.3.0"
 }
 
 description = "Implementation of the Mockito API for use on the Android Dalvik VM"
@@ -11,10 +11,14 @@ targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
 
 tasks.withType(JavaCompile) {
-    options.errorprone.errorproneArgs.add("-Xep:StringSplitter:OFF")
+    options.errorprone {
+        disable("StringSplitter")
+    }
 }
 
 dependencies {
+    errorprone "com.google.errorprone:error_prone_core:2.5.1"
+
     implementation project(':dexmaker')
 
     api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }

--- a/dexmaker/build.gradle
+++ b/dexmaker/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("net.ltgt.errorprone") version "0.8"
+    id("net.ltgt.errorprone") version "1.3.0"
 }
 
 description = "A utility for doing compile or runtime code generation targeting Android's Dalvik VM"
@@ -11,9 +11,17 @@ targetCompatibility = '1.7'
 sourceCompatibility = '1.7'
 
 tasks.withType(JavaCompile) {
-    options.errorprone.errorproneArgs.add("-Xep:StringSplitter:OFF")
+    options.errorprone {
+        disable("StringSplitter")
+    }
+}
+
+javadoc {
+    options.addBooleanOption("Xdoclint:-html", true)
 }
 
 dependencies {
+    errorprone "com.google.errorprone:error_prone_core:2.5.1"
+
     implementation 'com.jakewharton.android.repackaged:dalvik-dx:9.0.0_r3'
 }

--- a/dexmaker/build.gradle
+++ b/dexmaker/build.gradle
@@ -22,6 +22,7 @@ javadoc {
 
 dependencies {
     errorprone "com.google.errorprone:error_prone_core:2.5.1"
+    errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
     implementation 'com.jakewharton.android.repackaged:dalvik-dx:9.0.0_r3'
 }


### PR DESCRIPTION
I'm using java 13. This requires a newer version of the error prone plugin.

That in turn requires us to explicitly specify the error prone version. I also changed our build.gradles to use the new errorprone DSL.

Also, newer javadoc versions are more strict about HTML validation, which I have disabled via javadoc option.