### PR TITLE
Update to AGP 4.2 and remove JCenter dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,9 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.0'
     }
 }
 
@@ -13,7 +12,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     group = GROUP_ID

--- a/dexmaker-mockito-inline-dispatcher/build.gradle
+++ b/dexmaker-mockito-inline-dispatcher/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId 'com.android.dexmaker.mockito.inline.dispatcher'
         minSdkVersion 28
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionName VERSION_NAME
     }
 }

--- a/dexmaker-mockito-inline-extended-tests/build.gradle
+++ b/dexmaker-mockito-inline-extended-tests/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     android {
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         minSdkVersion 28
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionName VERSION_NAME
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/publishing_aar.gradle"
 description = 'Extension of the Mockito Inline API to allow mocking static methods on the Android Dalvik VM'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     android {
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionName VERSION_NAME
     }
 

--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     android {
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         minSdkVersion 28
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionName VERSION_NAME
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/publishing_aar.gradle"
 description = 'Implementation of the Mockito Inline API for use on the Android Dalvik VM'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     android {
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         minSdkVersion 1
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionName VERSION_NAME
     }
 

--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     android {
         lintOptions {
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionName VERSION_NAME
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/dexmaker-tests/build.gradle
+++ b/dexmaker-tests/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId 'com.linkedin.dexmaker'
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName VERSION_NAME
 


### PR DESCRIPTION
Also update compile/target SDK version to 29 because Lint now complains
about this.