### PR TITLE
Upgrade dexmaker to AGP 8.5

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Cache Gradle Files
         uses: actions/cache@v2
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - uses: gradle/wrapper-validation-action@v1
 

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Cache Gradle Files
         uses: actions/cache@v2

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Build
         run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:8.5.0'
     }
 }
 
@@ -16,4 +16,23 @@ allprojects {
 
     group = GROUP_ID
     version = VERSION_NAME
+
+    // The `errorprone` library now needs some additional exports to allow it to
+    // perform reflections. The flags passed to the JVM are from the errorprone
+    // documentation: https://errorprone.info/docs/installation.
+    tasks.withType(JavaCompile) {
+        options.fork = true
+	options.forkOptions.jvmArgs += [
+	   "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+           "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+           "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+           "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+           "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+           "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+           "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+           "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+           "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+           "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
+	]
+    }
 }

--- a/dexmaker-mockito-inline-dispatcher/build.gradle
+++ b/dexmaker-mockito-inline-dispatcher/build.gradle
@@ -1,12 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.android.dexmaker.mockito.inline.dispatcher'
     compileSdkVersion 32
 
     defaultConfig {
         applicationId 'com.android.dexmaker.mockito.inline.dispatcher'
         minSdkVersion 28
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionName VERSION_NAME
     }
 }

--- a/dexmaker-mockito-inline-dispatcher/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-inline-dispatcher/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest package="com.android.dexmaker.mockito.inline.dispatcher">
+<manifest>
     <application />
 </manifest>

--- a/dexmaker-mockito-inline-extended-tests/build.gradle
+++ b/dexmaker-mockito-inline-extended-tests/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.android.dexmaker.mockito.inline.extended.tests'
     compileSdkVersion 32
 
     android {
@@ -11,7 +12,7 @@ android {
 
     defaultConfig {
         minSdkVersion 28
-        targetSdkVersion 32
+        targetSdkVersion 33
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/dexmaker-mockito-inline-extended-tests/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-inline-extended-tests/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest package="com.android.dexmaker.mockito.inline.extended.tests"
+<manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -7,6 +7,7 @@ apply from: "$rootDir/gradle/publishing_aar.gradle"
 description = 'Extension of the Mockito Inline API to allow mocking static methods on the Android Dalvik VM'
 
 android {
+    namespace 'com.android.dx.mockito.inline.extended'
     compileSdkVersion 32
 
     android {
@@ -17,8 +18,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 32
+        minSdkVersion 21
+        targetSdkVersion 33
     }
 
     externalNativeBuild {
@@ -40,7 +41,7 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    errorprone "com.google.errorprone:error_prone_core:2.5.1"
+    errorprone "com.google.errorprone:error_prone_core:2.29.2"
     errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
     implementation project(':dexmaker-mockito-inline')

--- a/dexmaker-mockito-inline-extended/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-inline-extended/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.android.dx.mockito.inline.extended" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/MarkerToHandlerMap.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/MarkerToHandlerMap.java
@@ -84,6 +84,7 @@ class MarkerToHandlerMap implements Map<Object, InvocationHandlerAdapter> {
     }
 
     @Override
+    @SuppressWarnings("InfiniteRecursion")
     public Set<Entry<Object, InvocationHandlerAdapter>> entrySet() {
         Set<Entry<Object, InvocationHandlerAdapter>> set = new HashSet<>(entrySet().size());
         for (Entry<MockMarkerKey, InvocationHandlerAdapter> entry : markerToHandler.entrySet()) {

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/StaticMockMethodAdvice.java
@@ -115,6 +115,7 @@ class StaticMockMethodAdvice {
      * @param methodParameters Parameter of method
      * @return {code true} iff the method would have be handled by superClass
      */
+    @SuppressWarnings("ReturnValueIgnored")
     private static boolean isMethodDefinedBySuperClass(Class<?> subclass, Class<?> superClass,
                                                        String methodName,
                                                        Class<?>[] methodParameters) {

--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.android.dexmaker.mockito.inline.tests'
     compileSdkVersion 32
 
     android {
@@ -12,7 +13,7 @@ android {
 
     defaultConfig {
         minSdkVersion 28
-        targetSdkVersion 32
+        targetSdkVersion 33
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/dexmaker-mockito-inline-tests/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-inline-tests/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:tools="http://schemas.android.com/tools"
-    package="com.android.dexmaker.mockito.inline.tests"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <application android:debuggable="true"
         tools:ignore="HardcodedDebugMode" />

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -7,6 +7,7 @@ apply from: "$rootDir/gradle/publishing_aar.gradle"
 description = 'Implementation of the Mockito Inline API for use on the Android Dalvik VM'
 
 android {
+    namespace 'com.android.dx.mockito.inline'
     compileSdkVersion 32
 
     android {
@@ -17,8 +18,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 1
-        targetSdkVersion 32
+        minSdkVersion 21
+        targetSdkVersion 33
     }
 
     externalNativeBuild {
@@ -35,7 +36,7 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    errorprone "com.google.errorprone:error_prone_core:2.5.1"
+    errorprone "com.google.errorprone:error_prone_core:2.29.2"
     errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
     implementation project(':dexmaker')

--- a/dexmaker-mockito-inline/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-inline/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest package="com.android.dx.mockito.inline">
+<manifest>
     <application />
 </manifest>

--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.android.dexmaker.mockito.tests'
     compileSdkVersion 32
 
     android {
@@ -11,8 +12,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 32
+        minSdkVersion 21
+        targetSdkVersion 33
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/dexmaker-mockito-tests/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-tests/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:tools="http://schemas.android.com/tools"
-    package="com.android.dexmaker.mockito.tests"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <application android:debuggable="true"
         tools:ignore="HardcodedDebugMode"/>

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -7,8 +7,8 @@ description = "Implementation of the Mockito API for use on the Android Dalvik V
 apply plugin: 'java-library'
 apply from: "$rootDir/gradle/publishing.gradle"
 
-targetCompatibility = '1.7'
-sourceCompatibility = '1.7'
+java.targetCompatibility = '1.7'
+java.sourceCompatibility = '1.7'
 
 tasks.withType(JavaCompile) {
     options.errorprone {
@@ -17,7 +17,7 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    errorprone "com.google.errorprone:error_prone_core:2.5.1"
+    errorprone "com.google.errorprone:error_prone_core:2.29.2"
     errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
     implementation project(':dexmaker')

--- a/dexmaker-tests/build.gradle
+++ b/dexmaker-tests/build.gradle
@@ -1,12 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.linkedin.dexmaker'
     compileSdkVersion 32
 
     defaultConfig {
         applicationId 'com.linkedin.dexmaker'
-        minSdkVersion 14
-        targetSdkVersion 32
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode 1
         versionName VERSION_NAME
 

--- a/dexmaker-tests/src/main/AndroidManifest.xml
+++ b/dexmaker-tests/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<manifest package="com.linkedin.dexmaker"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/dexmaker/build.gradle
+++ b/dexmaker/build.gradle
@@ -7,8 +7,8 @@ description = "A utility for doing compile or runtime code generation targeting 
 apply plugin: 'java'
 apply from: "$rootDir/gradle/publishing.gradle"
 
-targetCompatibility = '1.7'
-sourceCompatibility = '1.7'
+java.targetCompatibility = '1.7'
+java.sourceCompatibility = '1.7'
 
 tasks.withType(JavaCompile) {
     options.errorprone {
@@ -21,7 +21,7 @@ javadoc {
 }
 
 dependencies {
-    errorprone "com.google.errorprone:error_prone_core:2.5.1"
+    errorprone "com.google.errorprone:error_prone_core:2.29.2"
     errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
     implementation 'com.jakewharton.android.repackaged:dalvik-dx:9.0.0_r3'

--- a/dexmaker/src/main/java/com/android/dx/AppDataDirGuesser.java
+++ b/dexmaker/src/main/java/com/android/dx/AppDataDirGuesser.java
@@ -29,6 +29,7 @@ class AppDataDirGuesser {
     // Copied from UserHandle, indicates range of uids allocated for a user.
     public static final int PER_USER_RANGE = 100000;
 
+    @SuppressWarnings("ReturnValueIgnored")
     public File guess() {
         try {
             ClassLoader classLoader = guessSuitableClassLoader();

--- a/dexmaker/src/main/java/com/android/dx/stock/ProxyBuilder.java
+++ b/dexmaker/src/main/java/com/android/dx/stock/ProxyBuilder.java
@@ -434,6 +434,7 @@ public final class ProxyBuilder<T> {
     /**
      * Returns true if {@code c} is a proxy class created by this builder.
      */
+    @SuppressWarnings("ReturnValueIgnored")
     public static boolean isProxyClass(Class<?> c) {
         // TODO: use a marker interface instead?
         try {

--- a/gradle/publishing_aar.gradle
+++ b/gradle/publishing_aar.gradle
@@ -1,21 +1,13 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-tasks.register("sourcesJar", Jar) {
-    classifier 'sources'
-    from android.sourceSets.main.java.srcDirs
-}
-
-tasks.register("javadoc", Javadoc) {
-    failOnError false
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-tasks.register("javadocJar", Jar) {
-    dependsOn javadoc
-    classifier 'javadoc'
-    from javadoc.destinationDir
+android {
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 // AGP creates the components in afterEvaluate, so we need to use it too
@@ -25,9 +17,6 @@ afterEvaluate {
         publications {
             maven(MavenPublication) {
                 from components.release
-
-                artifact sourcesJar
-                artifact javadocJar
 
                 pom {
                     name = 'Dexmaker'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The intent of this change is to migrate to Android Gradle Plugin 8.5.0, but as a consequence introduces a few other changes:

* The minimum viable SDK is now 21, as NDK r26 dropped support for 19.
* The minimum Gradle version is now 8, as AGP 8.5.0 requires it.
* The minimum JDK version is now 17, as AGP 8.5.0 requires it.
* The errorprone library was upgraded to provide new JDK classes.
* The publishing scripts were updated to use the new Gradle properties.
* Errorprone fixes were applied to the inline-extended classes.