### PR TITLE
Implement singleton mocks for dexmaker-mockito-inline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.10.0'
+        classpath 'com.android.tools.build:gradle:8.13.2'
     }
 }
 

--- a/dexmaker-mockito-inline-extended-tests/build.gradle
+++ b/dexmaker-mockito-inline-extended-tests/build.gradle
@@ -30,5 +30,5 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
 
-    androidTestImplementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
+    androidTestImplementation libs.mockito.core, { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/AndroidManifest.xml
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity android:name="com.android.dx.mockito.inline.extended.tests.EmptyActivity"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockStatic.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/MockStatic.java
@@ -25,7 +25,7 @@ import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockingDeta
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockitoSession;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.reset;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.staticMockMarker;
-import static com.android.dx.mockito.inline.extended.ExtendedMockito.verifyZeroInteractions;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.verifyNoInteractions;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.when;
 
 import static org.junit.Assert.assertEquals;
@@ -401,7 +401,7 @@ public class MockStatic {
         try {
             SuperClass.returnB();
             clearInvocations(staticMockMarker(SuperClass.class));
-            verifyZeroInteractions(staticMockMarker(SuperClass.class));
+            verifyNoInteractions(staticMockMarker(SuperClass.class));
         } finally {
             session.finishMocking();
         }

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/StaticMockitoSessionVsMockitoJUnitRunner.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/StaticMockitoSessionVsMockitoJUnitRunner.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class StaticMockitoSessionVsMockitoJUnitRunner {
     @Test
     public void simpleStubbing() throws Exception {

--- a/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/VerifyStatic.java
+++ b/dexmaker-mockito-inline-extended-tests/src/androidTest/java/com/android/dx/mockito/inline/extended/tests/VerifyStatic.java
@@ -30,7 +30,7 @@ import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockitoSess
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.staticMockMarker;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.verify;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.verifyNoMoreInteractions;
-import static com.android.dx.mockito.inline.extended.ExtendedMockito.verifyZeroInteractions;
+import static com.android.dx.mockito.inline.extended.ExtendedMockito.verifyNoInteractions;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.when;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -180,7 +180,7 @@ public class VerifyStatic {
         MockitoSession session = mockitoSession().mockStatic(EchoClass.class).startMocking();
         try {
             EchoClass.echo("marco!");
-            verifyZeroInteractions(staticMockMarker(EchoClass.class));
+            verifyNoInteractions(staticMockMarker(EchoClass.class));
             fail();
         } finally {
             session.finishMocking();

--- a/dexmaker-mockito-inline-extended-tests/src/main/AndroidManifest.xml
+++ b/dexmaker-mockito-inline-extended-tests/src/main/AndroidManifest.xml
@@ -3,7 +3,5 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application android:debuggable="true"
-        tools:ignore="HardcodedDebugMode">
-        <activity android:name="com.android.dx.mockito.inline.extended.tests.EmptyActivity" />
-    </application>
+        tools:ignore="HardcodedDebugMode" />
 </manifest>

--- a/dexmaker-mockito-inline-extended/build.gradle
+++ b/dexmaker-mockito-inline-extended/build.gradle
@@ -46,5 +46,5 @@ dependencies {
 
     implementation project(':dexmaker-mockito-inline')
 
-    api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
+    api libs.mockito.core, { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticInOrder.java
+++ b/dexmaker-mockito-inline-extended/src/main/java/com/android/dx/mockito/inline/extended/StaticInOrder.java
@@ -17,6 +17,7 @@
 package com.android.dx.mockito.inline.extended;
 
 import org.mockito.InOrder;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.verification.VerificationMode;
 
@@ -139,6 +140,12 @@ public class StaticInOrder implements InOrder {
     @UnstableApi
     public void verify(MockedMethod method, VerificationMode mode) {
         verify((MockedVoidMethod) method::get, mode);
+    }
+
+    @Override
+    public void verify(MockedStatic<?> mockedStatic, MockedStatic.Verification verification,
+            VerificationMode mode) {
+        instanceInOrder.verify(mockedStatic, verification, mode);
     }
 
     @Override

--- a/dexmaker-mockito-inline-tests/build.gradle
+++ b/dexmaker-mockito-inline-tests/build.gradle
@@ -30,5 +30,5 @@ dependencies {
 
     androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
+    androidTestImplementation libs.mockito.core, { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/MockSingleton.java
+++ b/dexmaker-mockito-inline-tests/src/androidTest/java/com/android/dx/mockito/inline/tests/MockSingleton.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.dx.mockito.inline.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mockSingleton;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedSingleton;
+
+@RunWith(AndroidJUnit4.class)
+public class MockSingleton {
+
+    enum SingleEnum {
+        VALUE_A {
+            @Override
+            String greeting() {
+                return "hello";
+            }
+        },
+        VALUE_B {
+            @Override
+            String greeting() {
+                return "world";
+            }
+        };
+
+        abstract String greeting();
+
+        int compute(int x) {
+            return x + 1;
+        }
+    }
+
+    static class SimpleSingleton {
+        static final SimpleSingleton INSTANCE = new SimpleSingleton();
+
+        String getValue() {
+            return "original";
+        }
+
+        int add(int a, int b) {
+            return a + b;
+        }
+    }
+
+    @Test
+    public void mockEnumSingleton() {
+        assertEquals("hello", SingleEnum.VALUE_A.greeting());
+
+        try (MockedSingleton<SingleEnum> mocked = mockSingleton(SingleEnum.VALUE_A)) {
+            when(SingleEnum.VALUE_A.greeting()).thenReturn("mocked");
+            assertEquals("mocked", SingleEnum.VALUE_A.greeting());
+        }
+
+        assertEquals("hello", SingleEnum.VALUE_A.greeting());
+    }
+
+    @Test
+    public void mockEnumDoesNotAffectOtherValues() {
+        try (MockedSingleton<SingleEnum> mocked = mockSingleton(SingleEnum.VALUE_A)) {
+            when(SingleEnum.VALUE_A.greeting()).thenReturn("mocked");
+
+            assertEquals("mocked", SingleEnum.VALUE_A.greeting());
+            assertEquals("world", SingleEnum.VALUE_B.greeting());
+        }
+    }
+
+    @Test
+    public void mockSingletonInstance() {
+        assertEquals("original", SimpleSingleton.INSTANCE.getValue());
+
+        try (MockedSingleton<SimpleSingleton> mocked = mockSingleton(SimpleSingleton.INSTANCE)) {
+            when(SimpleSingleton.INSTANCE.getValue()).thenReturn("mocked");
+            assertEquals("mocked", SimpleSingleton.INSTANCE.getValue());
+        }
+
+        assertEquals("original", SimpleSingleton.INSTANCE.getValue());
+    }
+
+    @Test
+    public void getInstanceReturnsSameObject() {
+        try (MockedSingleton<SingleEnum> mocked = mockSingleton(SingleEnum.VALUE_A)) {
+            assertSame(SingleEnum.VALUE_A, mocked.getInstance());
+        }
+    }
+
+    @Test
+    public void resetClearsStubs() {
+        try (MockedSingleton<SingleEnum> mocked = mockSingleton(SingleEnum.VALUE_A)) {
+            when(SingleEnum.VALUE_A.greeting()).thenReturn("mocked");
+            assertEquals("mocked", SingleEnum.VALUE_A.greeting());
+
+            reset(SingleEnum.VALUE_A);
+            // After reset, default mock behavior returns null for objects
+            assertEquals(null, SingleEnum.VALUE_A.greeting());
+        }
+    }
+
+    @Test
+    public void verifyInteraction() {
+        try (MockedSingleton<SimpleSingleton> mocked = mockSingleton(SimpleSingleton.INSTANCE)) {
+            SimpleSingleton.INSTANCE.getValue();
+
+            verify(SimpleSingleton.INSTANCE).getValue();
+        }
+    }
+
+    @Test
+    public void stubMethodWithArgs() {
+        try (MockedSingleton<SimpleSingleton> mocked = mockSingleton(SimpleSingleton.INSTANCE)) {
+            when(SimpleSingleton.INSTANCE.add(2, 3)).thenReturn(99);
+
+            assertEquals(99, SimpleSingleton.INSTANCE.add(2, 3));
+            assertEquals(0, SimpleSingleton.INSTANCE.add(1, 1));
+        }
+
+        assertEquals(2, SimpleSingleton.INSTANCE.add(1, 1));
+    }
+}

--- a/dexmaker-mockito-inline/build.gradle
+++ b/dexmaker-mockito-inline/build.gradle
@@ -41,5 +41,5 @@ dependencies {
 
     implementation project(':dexmaker')
 
-    api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
+    api libs.mockito.core, { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/ClassTransformer.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/ClassTransformer.java
@@ -94,11 +94,12 @@ class ClassTransformer {
      *              mocked or not.
      */
     ClassTransformer(JvmtiAgent agent, Class dispatcherClass,
-                     Map<Object, InvocationHandlerAdapter> mocks) {
+                     Map<Object, InvocationHandlerAdapter> mocks,
+                     ThreadLocal<Map<Object, InvocationHandlerAdapter>> singletonMocks) {
         this.agent = agent;
         mockedTypes = Collections.synchronizedSet(new HashSet<Class<?>>());
         identifier = String.valueOf(System.identityHashCode(this));
-        MockMethodAdvice advice = new MockMethodAdvice(mocks);
+        MockMethodAdvice advice = new MockMethodAdvice(mocks, singletonMocks);
 
         try {
             dispatcherClass.getMethod("set", String.class, Object.class).invoke(null, identifier,

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InlineDexmakerMockMaker.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/InlineDexmakerMockMaker.java
@@ -44,8 +44,10 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -167,6 +169,9 @@ public final class InlineDexmakerMockMaker implements InlineMockMaker {
      */
     private final Map<Object, InvocationHandlerAdapter> mocks;
 
+    private final ThreadLocal<Map<Object, InvocationHandlerAdapter>> singletonMocks =
+            new ThreadLocal<>();
+
     /**
      * Class doing the actual byte code transformation.
      */
@@ -185,7 +190,7 @@ public final class InlineDexmakerMockMaker implements InlineMockMaker {
         }
 
         mocks = new MockMap();
-        classTransformer = new ClassTransformer(AGENT, DISPATCHER_CLASS, mocks);
+        classTransformer = new ClassTransformer(AGENT, DISPATCHER_CLASS, mocks, singletonMocks);
     }
 
     /**
@@ -362,6 +367,54 @@ public final class InlineDexmakerMockMaker implements InlineMockMaker {
         return adapter != null ? adapter.getHandler() : null;
     }
 
+    @Override
+    public <T> SingletonMockControl<T> createSingletonMock(T instance, MockCreationSettings<T> settings, MockHandler handler) {
+        Class<T> typeToMock = settings.getTypeToMock();
+        Set<Class<?>> interfacesSet = settings.getExtraInterfaces();
+
+        classTransformer.mockClass(MockFeatures.withMockFeatures(typeToMock, interfacesSet));
+
+        InvocationHandlerAdapter handlerAdapter = new InvocationHandlerAdapter(handler);
+
+        return new InlineSingletonMockControl<>(instance, handlerAdapter);
+    }
+
+    private class InlineSingletonMockControl<T> implements SingletonMockControl<T> {
+        private final T instance;
+        private final InvocationHandlerAdapter handlerAdapter;
+
+        InlineSingletonMockControl(T instance, InvocationHandlerAdapter handlerAdapter) {
+            this.instance = instance;
+            this.handlerAdapter = handlerAdapter;
+        }
+
+        @Override
+        public T getInstance() {
+            return instance;
+        }
+
+        @Override
+        public void enable() {
+            Map<Object, InvocationHandlerAdapter> singletons = singletonMocks.get();
+            if (singletons == null) {
+                singletons = new IdentityHashMap<>();
+                singletonMocks.set(singletons);
+            }
+            singletons.put(instance, handlerAdapter);
+        }
+
+        @Override
+        public void disable() {
+            Map<Object, InvocationHandlerAdapter> singletons = singletonMocks.get();
+            if (singletons != null) {
+                singletons.remove(instance);
+                if (singletons.isEmpty()) {
+                    singletonMocks.remove();
+                }
+            }
+        }
+    }
+
     /**
      * Get the {@link InvocationHandlerAdapter} registered for a mock.
      *
@@ -374,7 +427,14 @@ public final class InlineDexmakerMockMaker implements InlineMockMaker {
             return null;
         }
 
-        return mocks.get(instance);
+        InvocationHandlerAdapter adapter = mocks.get(instance);
+        if (adapter == null) {
+            Map<Object, InvocationHandlerAdapter> singletons = singletonMocks.get();
+            if (singletons != null) {
+                adapter = singletons.get(instance);
+            }
+        }
+        return adapter;
     }
 
     /**

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
@@ -89,7 +89,7 @@ class JvmtiAgent {
         copiedAgent.deleteOnExit();
 
         InputStream is;
-        if (path != null) {
+        if (path != null && new File(path).isFile()) {
             is = new FileInputStream(path);
         } else {
             // findLibrary returned null — try loading from APK resources

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
@@ -80,7 +80,7 @@ class JvmtiAgent {
     private static String resolveAgentPath(ClassLoader cl) throws IOException {
         String path = ((BaseDexClassLoader) cl).findLibrary("dexmakerjvmtiagent");
 
-        if (path != null && !path.contains("=") && !path.contains("!")) {
+        if (path != null && !path.contains("=")) {
             return path;
         }
 

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/JvmtiAgent.java
@@ -80,7 +80,7 @@ class JvmtiAgent {
     private static String resolveAgentPath(ClassLoader cl) throws IOException {
         String path = ((BaseDexClassLoader) cl).findLibrary("dexmakerjvmtiagent");
 
-        if (path != null && !path.contains("=")) {
+        if (path != null && !path.contains("=") && !path.contains("!")) {
             return path;
         }
 

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
@@ -23,7 +23,6 @@ import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.InlineMockMaker;
 import org.mockito.plugins.MockMaker;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 
 /**
@@ -36,7 +35,7 @@ public final class MockMakerMultiplexer implements InlineMockMaker {
     static {
         String[] potentialMockMakers = new String[] {
                 "com.android.dx.mockito.inline.InlineStaticMockMaker",
-                InlineDexmakerMockMaker.class.getName()
+                "com.android.dx.mockito.inline.InlineDexmakerMockMaker"
         };
 
         ArrayList<MockMaker> mockMakers = new ArrayList<>();
@@ -45,14 +44,10 @@ public final class MockMakerMultiplexer implements InlineMockMaker {
                 Class<? extends MockMaker> mockMakerClass = (Class<? extends MockMaker>)
                         Class.forName(potentialMockMaker);
                 mockMakers.add(mockMakerClass.getDeclaredConstructor().newInstance());
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-                    | NoSuchMethodException | InvocationTargetException e) {
-                if (potentialMockMaker.equals(InlineDexmakerMockMaker.class.getName())) {
-                    Log.e(LOG_TAG, "Could not init mockmaker " + potentialMockMaker, e);
-                } else {
-                    // Additional mock makers might not be loaded
-                    Log.e(LOG_TAG, "Could not init mockmaker " + potentialMockMaker);
-                }
+            } catch (Exception e) {
+                Log.e(LOG_TAG, "Could not init mockmaker " + potentialMockMaker, e);
+            } catch (Error e) {
+                Log.e(LOG_TAG, "Could not init mockmaker " + potentialMockMaker, e);
             }
         }
 
@@ -102,7 +97,17 @@ public final class MockMakerMultiplexer implements InlineMockMaker {
             }
         }
 
-        return null;
+        return new TypeMockability() {
+            @Override
+            public boolean mockable() {
+                return false;
+            }
+
+            @Override
+            public String nonMockableReason() {
+                return "No mock makers available to mock this type";
+            }
+        };
     }
 
     @Override

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMakerMultiplexer.java
@@ -18,11 +18,13 @@ package com.android.dx.mockito.inline;
 
 import android.util.Log;
 
+import org.mockito.exceptions.base.MockitoException;
 import org.mockito.invocation.MockHandler;
 import org.mockito.mock.MockCreationSettings;
 import org.mockito.plugins.InlineMockMaker;
 import org.mockito.plugins.MockMaker;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 
 /**
@@ -35,7 +37,7 @@ public final class MockMakerMultiplexer implements InlineMockMaker {
     static {
         String[] potentialMockMakers = new String[] {
                 "com.android.dx.mockito.inline.InlineStaticMockMaker",
-                "com.android.dx.mockito.inline.InlineDexmakerMockMaker"
+                InlineDexmakerMockMaker.class.getName()
         };
 
         ArrayList<MockMaker> mockMakers = new ArrayList<>();
@@ -44,10 +46,14 @@ public final class MockMakerMultiplexer implements InlineMockMaker {
                 Class<? extends MockMaker> mockMakerClass = (Class<? extends MockMaker>)
                         Class.forName(potentialMockMaker);
                 mockMakers.add(mockMakerClass.getDeclaredConstructor().newInstance());
-            } catch (Exception e) {
-                Log.e(LOG_TAG, "Could not init mockmaker " + potentialMockMaker, e);
-            } catch (Error e) {
-                Log.e(LOG_TAG, "Could not init mockmaker " + potentialMockMaker, e);
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                    | NoSuchMethodException | InvocationTargetException e) {
+                if (potentialMockMaker.equals(InlineDexmakerMockMaker.class.getName())) {
+                    Log.e(LOG_TAG, "Could not init mockmaker " + potentialMockMaker, e);
+                } else {
+                    // Additional mock makers might not be loaded
+                    Log.e(LOG_TAG, "Could not init mockmaker " + potentialMockMaker);
+                }
             }
         }
 
@@ -132,5 +138,19 @@ public final class MockMakerMultiplexer implements InlineMockMaker {
             InlineMockMaker inlineMockMaker = (InlineMockMaker) mockMaker;
             inlineMockMaker.clearAllMocks();
         }
+    }
+
+    @Override
+    public <T> SingletonMockControl<T> createSingletonMock(
+            T instance, MockCreationSettings<T> settings, MockHandler handler) {
+        for (MockMaker mockMaker : MOCK_MAKERS) {
+            try {
+                return mockMaker.createSingletonMock(instance, settings, handler);
+            } catch (MockitoException ignored) {
+            }
+        }
+        throw new MockitoException(
+                "The used MockMaker MockMakerMultiplexer does not support the creation of "
+                + "singleton mocks\n\nEnsure your MockMaker implementation supports this feature.");
     }
 }

--- a/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMethodAdvice.java
+++ b/dexmaker-mockito-inline/src/main/java/com/android/dx/mockito/inline/MockMethodAdvice.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
  */
 class MockMethodAdvice {
     private final Map<Object, InvocationHandlerAdapter> interceptors;
+    private final ThreadLocal<Map<Object, InvocationHandlerAdapter>> singletonInterceptors;
 
     /** Pattern to decompose a instrumentedMethodWithTypeAndSignature */
     private final Pattern methodPattern = Pattern.compile("(.*)#(.*)\\((.*)\\)");
@@ -32,8 +33,21 @@ class MockMethodAdvice {
     @SuppressWarnings("ThreadLocalUsage")
     private final SelfCallInfo selfCallInfo = new SelfCallInfo();
 
-    MockMethodAdvice(Map<Object, InvocationHandlerAdapter> interceptors) {
+    MockMethodAdvice(Map<Object, InvocationHandlerAdapter> interceptors,
+                     ThreadLocal<Map<Object, InvocationHandlerAdapter>> singletonInterceptors) {
         this.interceptors = interceptors;
+        this.singletonInterceptors = singletonInterceptors;
+    }
+
+    private InvocationHandlerAdapter getInterceptor(Object instance) {
+        InvocationHandlerAdapter interceptor = interceptors.get(instance);
+        if (interceptor == null && singletonInterceptors != null) {
+            Map<Object, InvocationHandlerAdapter> singletons = singletonInterceptors.get();
+            if (singletons != null) {
+                interceptor = singletons.get(instance);
+            }
+        }
+        return interceptor;
     }
 
     /**
@@ -225,7 +239,7 @@ class MockMethodAdvice {
      */
     @SuppressWarnings("unused")
     public Callable<?> handle(Object instance, Method origin, Object[] arguments) throws Throwable {
-        InvocationHandlerAdapter interceptor = interceptors.get(instance);
+        InvocationHandlerAdapter interceptor = getInterceptor(instance);
         if (interceptor == null) {
             return null;
         }
@@ -242,7 +256,7 @@ class MockMethodAdvice {
      * @return {@code true} iff the instance is a mock
      */
     public boolean isMock(Object instance) {
-        return interceptors.containsKey(instance);
+        return getInterceptor(instance) != null;
     }
 
     /**

--- a/dexmaker-mockito-tests/build.gradle
+++ b/dexmaker-mockito-tests/build.gradle
@@ -24,5 +24,5 @@ dependencies {
 
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
+    androidTestImplementation libs.mockito.core, { exclude group: 'net.bytebuddy' }
 }

--- a/dexmaker-mockito/build.gradle
+++ b/dexmaker-mockito/build.gradle
@@ -22,5 +22,5 @@ dependencies {
 
     implementation project(':dexmaker')
 
-    api 'org.mockito:mockito-core:2.28.2', { exclude group: 'net.bytebuddy' }
+    api libs.mockito.core, { exclude group: 'net.bytebuddy' }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+mockito = "5.23.0"
+
+[libraries]
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Explanation of changes:
- "Fix dexmaker-mockito-inline integration tests"

This fixes `JvmtiAgent` attach if `ClassLoader.findLibrary()` returns an in-apk path like `/data/app/(...base64...)==/com.android.dexmaker.mockito.inline.tests.test-GYPbtVtChs6-x4dXoXF5Mg==/base.apk!/lib/arm64-v8a/libdexmakerjvmtiagent.so` - this was the case for the tests in this repo. PR #210 inadvertently broke the tests.

- Upgrade AGP to 8.13.2

Enables running tests on newer Android emulators

- Upgrade Mockito to 5.X

Syncs to latest `mockito-core` dependency and accommodating breaking API changes.

- Implement createSingletonMock in InlineDexmakerMockMaker

Mockito 5.23.0 introduced a new `mockSingleton` API which enabled a new API in mockito-kotlin to mock Kotlin objects. This adds support for this behavior on Android so Mockito users can use this new feature on Android tests.


_____

Test plan:
- gradle sync succeeds
- `./gradlew connectedAndroidTest` - all tests pass,checked on API 30 and API 36 emulators
- publish dexmaker-mockito-inline to local maven and verify mockito-android integration tests still pass